### PR TITLE
Add page number display to list views

### DIFF
--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -219,7 +219,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                 .await
                 .context("Failed to fetch bugs from repository")?;
 
-            crate::output::output_list(&bugs.bugs, bugs.total, format)
+            crate::output::output_list(&bugs.bugs, bugs.total, *page, *limit, format)
         }
 
         BugCommands::Show { bug_id } => {

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -29,7 +29,7 @@ pub async fn handle(command: &RepoCommands, cli: &crate::Cli) -> Result<()> {
             let repos = client.list_repos(*limit, offset).await
                 .context("Failed to fetch repositories")?;
 
-            crate::output::output_list(&repos.repos, repos.total, format)
+            crate::output::output_list(&repos.repos, repos.total, *page, *limit, format)
         }
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -23,13 +23,19 @@ pub trait Formattable {
 pub fn output_list<T: Formattable + Serialize>(
     items: &[T],
     total: usize,
+    page: u32,
+    limit: u32,
     format: &crate::OutputFormat,
 ) -> Result<()> {
+    let total_pages = (total as u32).div_ceil(limit).max(1);
+
     match format {
         crate::OutputFormat::Json => {
             let response = serde_json::json!({
                 "items": items,
                 "total": total,
+                "page": page,
+                "total_pages": total_pages,
             });
             println!("{}", serde_json::to_string_pretty(&response)?);
         }
@@ -49,7 +55,7 @@ pub fn output_list<T: Formattable + Serialize>(
                 table.add_row(Row::new(item.to_table_row()));
             }
             table.printstd();
-            println!("\nTotal: {}", total);
+            println!("\nPage: {} of {}", page, total_pages);
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
- Display `Page: X of Y` instead of `Total: N` in table output for bugs and repos list commands
- Add `page` and `total_pages` fields to JSON output format

## Test plan
- [x] Verified with `detail bugs list usedetail/detail` — shows `Page: 1 of 11`
- [x] Test with `--page` flag to confirm correct page numbers
- [x] Test with `--format json` to verify JSON includes page info

🤖 Generated with [Claude Code](https://claude.com/claude-code)