### PR TITLE
refactor: use typed enums in BugReviewRequest

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -163,14 +163,14 @@ impl ApiClient {
     pub async fn update_bug_review(
         &self,
         bug_id: &BugId,
-        state: &str,
-        dismissal_reason: Option<&str>,
+        state: BugReviewState,
+        dismissal_reason: Option<BugDismissalReason>,
         notes: Option<&str>,
     ) -> Result<BugReview> {
         let path = format!("/public/v1/bugs/{}/review", bug_id);
         let request = BugReviewRequest {
-            state: state.to_string(),
-            dismissal_reason: dismissal_reason.map(String::from),
+            state,
+            dismissal_reason,
             notes: notes.map(String::from),
         };
         let body = serde_json::to_value(request)?;

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -154,9 +154,9 @@ impl std::fmt::Display for BugDismissalReason {
 
 #[derive(Debug, Serialize)]
 pub struct BugReviewRequest {
-    pub state: String,
+    pub state: BugReviewState,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dismissal_reason: Option<String>,
+    pub dismissal_reason: Option<BugDismissalReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
 }


### PR DESCRIPTION
Replace raw String fields in BugReviewRequest with BugReviewState and
BugDismissalReason enums. Update ApiClient::update_bug_review to accept
the typed values instead of &str, making the API contract type-checked
at compile time.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>