### PR TITLE
refactor: consolidate duplicated CLI enums with api types

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -136,7 +136,7 @@ impl ApiClient {
     pub async fn list_bugs(
         &self,
         repo_id: &RepoId,
-        status: Option<&str>,
+        status: Option<&BugReviewState>,
         limit: u32,
         offset: u32,
     ) -> Result<BugsResponse> {
@@ -147,7 +147,10 @@ impl ApiClient {
             query.append_pair("limit", &limit.to_string());
             query.append_pair("offset", &offset.to_string());
             if let Some(s) = status {
-                query.append_pair("status", s);
+                let value = serde_json::to_value(s)?;
+                if let Some(status_str) = value.as_str() {
+                    query.append_pair("status", status_str);
+                }
             }
         }
         let path_and_query = format!("{}?{}", url.path(), url.query().unwrap_or(""));

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -114,7 +114,7 @@ pub struct BugReview {
     pub notes: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BugReviewState {
     Pending,
@@ -132,7 +132,7 @@ impl std::fmt::Display for BugReviewState {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum BugDismissalReason {
     NotABug,


### PR DESCRIPTION
Add Clone and clap::ValueEnum to BugReviewState and BugDismissalReason
in api/types.rs so they work directly as CLI arguments. Delete the
duplicated ReviewState, DismissalReason, and BugStatus enums from
commands/bugs.rs (~60 lines removed). Update list_bugs to accept
Option<&BugReviewState> instead of Option<&str>.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>