### PR TITLE
refactor: use serde_urlencoded for query parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,9 +413,9 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "tokio",
  "toml",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,11 @@ clap = { version = "4.5", features = ["derive", "cargo", "env"] }
 # HTTP client
 reqwest = { version = "0.13", features = ["json"] }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
-url = "2.5"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_urlencoded = "0.7"
 csv = "1.4"
 
 # Error handling


### PR DESCRIPTION
Replace manual url.query_pairs_mut().append_pair(...) pattern in
list_bugs and list_repos with typed query structs serialized via
serde_urlencoded. This makes the query parameter contract explicit
and type-checked, and removes the direct url crate dependency.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>