### PR TITLE
refactor: extract SectionRenderer for detail views

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,39 @@
 //! CLI output formatting utilities
 
 use anyhow::Result;
+use colored::Colorize;
 use prettytable::{Cell, Row, Table};
 use serde::Serialize;
+
+/// Renders detail views as sections with bold headers and terminal-width separators.
+pub struct SectionRenderer {
+    sections: Vec<(String, String)>,
+}
+
+impl SectionRenderer {
+    pub fn new() -> Self {
+        Self {
+            sections: Vec::new(),
+        }
+    }
+
+    pub fn section(mut self, header: &str, value: impl std::fmt::Display) -> Self {
+        self.sections.push((header.to_string(), value.to_string()));
+        self
+    }
+
+    pub fn print(self) {
+        let width = console::Term::stdout().size().1 as usize;
+        let separator = "─".repeat(width);
+
+        for (header, value) in &self.sections {
+            println!("{}", header.bold());
+            println!("{}", separator.dimmed());
+            println!("{}", value);
+            println!();
+        }
+    }
+}
 
 /// Trait for types that can be formatted as CSV or Table output
 pub trait Formattable {


### PR DESCRIPTION
## Summary
- Adds `SectionRenderer` to `output.rs` — a builder that collects `(header, value)` sections and renders them with bold headers and terminal-width `─` separators
- Refactors `bugs show` to use `SectionRenderer` instead of inline `println!()` calls and closures
- `SectionRenderer` is reusable for any future detail views (repos, reviews, etc.)

**Before (bugs.rs):**
```rust
let width = console::Term::stdout().size().1 as usize;
let separator = "─".repeat(width);
let section = |header: &str, value: &str| {
    println!("{}", header.bold());
    println!("{}", separator.dimmed());
    println!("{}", value);
    println!();
};
section("ID", &bug.id.to_string());
section("Title", &bug.title);
// ...
```

**After (bugs.rs):**
```rust
crate::output::SectionRenderer::new()
    .section("ID", &bug.id)
    .section("Title", &bug.title)
    // ...
    .print();
```

Stacked on #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)