### PR TITLE
refactor: add key_value() section method for aligned key-value pairs

### DIFF
--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -191,18 +191,17 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                         .unwrap_or("-"),
                 );
             if let Some(review) = &bug.review {
-                let mut review_text = format!("State:  {}", review.state);
-                review_text.push_str(&format!(
-                    "\nDate:   {}",
-                    crate::utils::format_datetime(review.created_at)
-                ));
+                let mut pairs = vec![
+                    ("State", review.state.to_string()),
+                    ("Date", crate::utils::format_datetime(review.created_at)),
+                ];
                 if let Some(reason) = &review.dismissal_reason {
-                    review_text.push_str(&format!("\nReason: {}", reason));
+                    pairs.push(("Reason", reason.to_string()));
                 }
                 if let Some(notes) = &review.notes {
-                    review_text.push_str(&format!("\nNotes:  {}", notes));
+                    pairs.push(("Notes", notes.clone()));
                 }
-                renderer = renderer.section("Review", review_text);
+                renderer = renderer.key_value("Review", &pairs);
             }
             renderer.markdown("Report", &bug.summary).print();
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -44,6 +44,19 @@ impl SectionRenderer {
         self
     }
 
+    /// Add a section with key-value pairs rendered as aligned rows.
+    pub fn key_value(mut self, header: &str, pairs: &[(&str, String)]) -> Self {
+        let max_key = pairs.iter().map(|(k, _)| k.len()).max().unwrap_or(0);
+        let text = pairs
+            .iter()
+            .map(|(k, v)| format!("{:<width$}  {}", k, v, width = max_key))
+            .collect::<Vec<_>>()
+            .join("\n");
+        self.sections
+            .push((header.to_string(), SectionContent::Plain(text)));
+        self
+    }
+
     pub fn markdown(mut self, header: &str, value: impl std::fmt::Display) -> Self {
         self.sections.push((
             header.to_string(),


### PR DESCRIPTION
Replace manual string building in the Review section with the new
key_value() helper that auto-aligns keys by padding to max key width.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>