### PR TITLE
refactor: return Result from SectionRenderer::print()

### DIFF
--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -203,9 +203,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                 }
                 renderer = renderer.key_value("Review", &pairs);
             }
-            renderer.markdown("Report", &bug.summary).print();
-
-            Ok(())
+            renderer.markdown("Report", &bug.summary).print()
         }
 
         BugCommands::Review {

--- a/src/output.rs
+++ b/src/output.rs
@@ -65,25 +65,25 @@ impl SectionRenderer {
         self
     }
 
-    pub fn print(self) {
+    pub fn print(self) -> Result<()> {
         let width = self.term.size().1 as usize;
         let separator = "─".repeat(width);
 
         for (header, content) in &self.sections {
-            let _ = self.term.write_line(&format!("{}", style(header).bold()));
-            let _ = self
-                .term
-                .write_line(&format!("{}", style(&separator).dim()));
+            self.term.write_line(&format!("{}", style(header).bold()))?;
+            self.term
+                .write_line(&format!("{}", style(&separator).dim()))?;
             match content {
                 SectionContent::Plain(text) => {
-                    let _ = self.term.write_line(text);
+                    self.term.write_line(text)?;
                 }
                 SectionContent::Markdown(text) => {
-                    let _ = write!(&self.term, "{}", MARKDOWN_SKIN.term_text(text));
+                    write!(&self.term, "{}", MARKDOWN_SKIN.term_text(text))?;
                 }
             }
-            let _ = self.term.write_line("");
+            self.term.write_line("")?;
         }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Propagate terminal write errors instead of silently discarding them
with let _ =. Callers can now use ? to bubble up IO failures.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>