### PR TITLE
refactor: derive Copy for BugReviewState and BugDismissalReason

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -113,7 +113,7 @@ pub struct BugReview {
     pub notes: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum BugReviewState {
     Pending,
@@ -131,7 +131,7 @@ impl std::fmt::Display for BugReviewState {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, clap::ValueEnum)]
 #[serde(rename_all = "snake_case")]
 pub enum BugDismissalReason {
     NotABug,

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -227,12 +227,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
             let bug_id = BugId::new(bug_id).map_err(|e| anyhow::anyhow!(e))?;
 
             client
-                .update_bug_review(
-                    &bug_id,
-                    state.clone(),
-                    dismissal_reason.clone(),
-                    notes.as_deref(),
-                )
+                .update_bug_review(&bug_id, *state, *dismissal_reason, notes.as_deref())
                 .await
                 .context("Failed to update bug review")?;
 


### PR DESCRIPTION
Small enums that don't need heap allocation. Replaces .clone() with
copy semantics at call sites.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>