### PR TITLE
refactor: deduplicate timestamp formatting with shared helper

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,16 +6,19 @@ pub fn page_to_offset(page: u32, limit: u32) -> u32 {
 /// Conversion factor from milliseconds to seconds
 const MS_TO_SECONDS: i64 = 1000;
 
+/// Format a timestamp (in milliseconds) using the given strftime format string.
+fn format_timestamp(timestamp_ms: i64, fmt: &str) -> String {
+    chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0)
+        .map(|dt| dt.format(fmt).to_string())
+        .unwrap_or_else(|| "-".into())
+}
+
 /// Format a timestamp (in milliseconds) as a date string (YYYY-MM-DD)
 pub fn format_date(timestamp_ms: i64) -> String {
-    chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0)
-        .map(|dt| dt.format("%Y-%m-%d").to_string())
-        .unwrap_or("-".into())
+    format_timestamp(timestamp_ms, "%Y-%m-%d")
 }
 
 /// Format a timestamp (in milliseconds) as a full datetime string (YYYY-MM-DD HH:MM:SS UTC)
 pub fn format_datetime(timestamp_ms: i64) -> String {
-    chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-        .unwrap_or("-".into())
+    format_timestamp(timestamp_ms, "%Y-%m-%d %H:%M:%S UTC")
 }


### PR DESCRIPTION
Extract format_timestamp() to eliminate duplicated DateTime parsing
and error handling between format_date() and format_datetime().

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>