### PR TITLE
feat: add `detail skill` command

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod auth;
 pub mod bugs;
 pub mod repos;
+pub mod skill;

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -1,0 +1,26 @@
+use anyhow::{Context, Result};
+use std::process::Command;
+
+const TRIAGE_SKILL_CONTENT: &str = include_str!("../../.claude/skills/triage-detail-bugs/SKILL.md");
+
+fn git_root() -> Result<std::path::PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .context("failed to run git")?;
+    anyhow::ensure!(output.status.success(), "not inside a git repository");
+    let root = String::from_utf8(output.stdout).context("git output was not valid UTF-8")?;
+    Ok(std::path::PathBuf::from(root.trim()))
+}
+
+pub fn handle() -> Result<()> {
+    let dir = git_root()?.join(".claude/skills/triage-detail-bugs");
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("SKILL.md");
+    std::fs::write(&path, TRIAGE_SKILL_CONTENT)?;
+    console::Term::stderr().write_line(&format!(
+        "Installed triage-detail-bugs skill to {}",
+        path.display()
+    ))?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,9 @@ enum Commands {
         command: commands::repos::RepoCommands,
     },
 
+    /// Install the triage-detail-bugs skill into the current repository
+    Skill,
+
     /// Show version information
     Version,
 }
@@ -78,6 +81,7 @@ async fn main() -> Result<()> {
         Commands::Auth { command } => commands::auth::handle(command, &cli).await,
         Commands::Bugs { command } => commands::bugs::handle(command, &cli).await,
         Commands::Repos { command } => commands::repos::handle(command, &cli).await,
+        Commands::Skill => commands::skill::handle(),
         Commands::Version => {
             console::Term::stdout().write_line(&format!("detail-cli v{}", VERSION))?;
             Ok(())


### PR DESCRIPTION
## Summary
- Adds a `detail skill` top-level command that installs the `triage-detail-bugs` SKILL.md into the current repo's `.claude/skills/` directory
- Resolves the git root via `git rev-parse --show-toplevel` so it works from any subdirectory
- Embeds the skill content at compile time with `include_str!` to stay in sync with the source

## Test plan
- [ ] `cargo check` compiles without warnings
- [ ] `cargo fmt -- --check` passes
- [ ] Run `detail skill` from a repo subdirectory and verify `.claude/skills/triage-detail-bugs/SKILL.md` is created at the repo root
- [ ] Run `detail skill` outside a git repo and verify a clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)