### PR TITLE
refactor: rename `bugs review` subcommand to `bugs close`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,19 @@ dependencies = [
 
 [[package]]
 name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.2",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
@@ -553,8 +566,9 @@ dependencies = [
  "axoupdater",
  "chrono",
  "clap",
- "console",
+ "console 0.16.2",
  "csv",
+ "dialoguer",
  "homedir",
  "reqwest 0.13.2",
  "semver",
@@ -564,6 +578,19 @@ dependencies = [
  "termimad",
  "tokio",
  "toml",
+]
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console 0.15.11",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -1949,6 +1976,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2786,6 +2819,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ homedir = "0.3"
 
 # Terminal UI
 console = "0.16"
+dialoguer = "0.11"
 termimad = "0.30"
 
 # Update checking (uses cargo-dist receipts)


### PR DESCRIPTION
refactor: rename `bugs review` subcommand to `bugs close`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

feat: add interactive prompts to `bugs close` command

When run in a TTY without flags, `bugs close` now guides users through
arrow-key selection for state and dismissal reason, plus text input for
notes. Full flag support is preserved for scripting and non-interactive
use.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>