### PR TITLE
Use generated API types directly, drop hand-written duplicates

### DIFF
--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -6,14 +6,6 @@ pub struct ApiClient {
     inner: super::generated::Client,
 }
 
-/// Convert a generated response type to one of our hand-written domain types
-/// by round-tripping through JSON. The generated types handle API deserialization
-/// (including timestamp quirks), then we re-deserialize into our types which
-/// have ID newtypes, field renames, etc.
-fn convert<T: serde::de::DeserializeOwned>(val: impl serde::Serialize) -> Result<T> {
-    serde_json::from_value(serde_json::to_value(val)?).map_err(Into::into)
-}
-
 impl ApiClient {
     pub fn new(base_url: Option<String>, token: Option<String>) -> Result<Self> {
         let base_url = base_url.unwrap_or_else(|| "https://api.detail.dev".into());
@@ -40,92 +32,69 @@ impl ApiClient {
     }
 
     pub async fn get_current_user(&self) -> Result<UserInfo> {
-        let resp = self
-            .inner
+        self.inner
             .get_public_user()
             .await
             .map(|r| r.into_inner())
-            .map_err(|e| anyhow::anyhow!("API error: {}", e))?;
-
-        convert(resp)
+            .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 
     pub async fn list_bugs(
         &self,
-        repo_id: &RepoId,
-        status: Option<&BugCloseState>,
+        repo_id: &str,
+        status: BugReviewState,
         limit: u32,
         offset: u32,
     ) -> Result<BugsResponse> {
         use std::num::NonZeroU64;
 
-        // Convert our BugCloseState to the generated BugReviewState via JSON
-        let gen_status: super::generated::types::BugReviewState = status
-            .map(convert)
-            .transpose()?
-            .unwrap_or(super::generated::types::BugReviewState::Pending);
-
-        let resp = self
-            .inner
+        self.inner
             .list_public_bugs(
                 NonZeroU64::new(limit as u64),
                 Some(offset as u64),
-                repo_id.as_str(),
-                gen_status,
+                repo_id,
+                status,
             )
             .await
             .map(|r| r.into_inner())
-            .map_err(|e| anyhow::anyhow!("API error: {}", e))?;
-
-        convert(resp)
+            .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 
-    pub async fn get_bug(&self, bug_id: &BugId) -> Result<Bug> {
-        let resp = self
-            .inner
-            .get_public_bug(bug_id.as_str())
+    pub async fn get_bug(&self, bug_id: &str) -> Result<Bug> {
+        self.inner
+            .get_public_bug(bug_id)
             .await
             .map(|r| r.into_inner())
-            .map_err(|e| anyhow::anyhow!("API error: {}", e))?;
-
-        convert(resp)
+            .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 
     pub async fn update_bug_close(
         &self,
-        bug_id: &BugId,
-        state: BugCloseState,
+        bug_id: &str,
+        state: BugReviewState,
         dismissal_reason: Option<BugDismissalReason>,
         notes: Option<&str>,
-    ) -> Result<BugClose> {
-        // Build the request body by converting our types through JSON
-        let body: super::generated::types::CreatePublicBugReviewBody =
-            serde_json::from_value(serde_json::json!({
-                "state": state,
-                "dismissalReason": dismissal_reason,
-                "notes": notes,
-            }))?;
+    ) -> Result<BugReview> {
+        let body = CreatePublicBugReviewBody {
+            state,
+            dismissal_reason,
+            notes: notes.map(String::from),
+        };
 
-        let resp = self
-            .inner
-            .create_public_bug_review(bug_id.as_str(), &body)
+        self.inner
+            .create_public_bug_review(bug_id, &body)
             .await
             .map(|r| r.into_inner())
-            .map_err(|e| anyhow::anyhow!("API error: {}", e))?;
-
-        convert(resp)
+            .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 
     pub async fn list_repos(&self, limit: u32, offset: u32) -> Result<ReposResponse> {
         use std::num::NonZeroU64;
 
-        let resp = self
-            .inner
+        self.inner
             .list_public_repos(NonZeroU64::new(limit as u64), Some(offset as u64))
             .await
             .map(|r| r.into_inner())
-            .map_err(|e| anyhow::anyhow!("API error: {}", e))?;
-
-        convert(resp)
+            .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
 pub mod client;
 #[allow(clippy::all, dead_code)]
-mod generated;
+pub(crate) mod generated;
 pub mod types;

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -63,7 +63,13 @@ pub async fn handle(command: &RepoCommands, cli: &crate::Cli) -> Result<()> {
                     term.write_line(&format!("Page: {} of {}", page, total_pages))?;
                     Ok(())
                 }
-                _ => crate::output::output_list(&repos.repos, repos.total, *page, *limit, format),
+                _ => crate::output::output_list(
+                    &repos.repos,
+                    repos.total as usize,
+                    *page,
+                    *limit,
+                    format,
+                ),
             }
         }
     }


### PR DESCRIPTION
## Summary

- Delete the hand-written domain types (`Bug`, `Repo`, `UserInfo`, `BugCloseState`, ID newtypes, etc.) and use the progenitor-generated types directly
- `types.rs` is now just re-exports, type aliases, and trait impls (`ValueEnum`, `Formattable`) on the generated types
- No more JSON round-trip conversion layer — client methods return generated types directly
- User-facing CLI text still says "close" (subcommand name, labels, prompts)

Net -120 lines.

## Test plan

- [x] `cargo build` — no warnings
- [x] `cargo test` — passes
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `make check` — help docs unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
