### PR TITLE
Fix POSIX-incompatible Makefile check-help target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ check-openapi:
 
 check-help:
 	@echo "Checking docs/HELP.md is up to date..."
-	@diff <(cargo run --quiet --example generate_help) docs/HELP.md
+	@cargo run --quiet --example generate_help | diff - docs/HELP.md
 
 generate: generate-openapi generate-help
 


### PR DESCRIPTION
## Summary

- Fix `check-help` Makefile target that used bash-only `<(...)` process substitution, which fails on CI where `/bin/sh` is dash
- Use `cargo run ... | diff - docs/HELP.md` instead

## Test plan

- [x] `make check` passes locally
- [x] Fixes CI failure on main (run 22083666792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)