### PR TITLE
feat: adopt typed ID newtypes from updated OpenAPI spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -587,6 +587,7 @@ dependencies = [
  "dialoguer",
  "homedir",
  "progenitor",
+ "regress",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ axoupdater = "0.9.1"
 
 # Date/time formatting
 chrono = "0.4"
+regress = "0.10.5"
 
 [dev-dependencies]
 clap-markdown = "0.1"

--- a/openapi.json
+++ b/openapi.json
@@ -20,6 +20,22 @@
             }
         },
         "schemas": {
+            "BugId": {
+                "type": "string",
+                "pattern": "^bug_.*"
+            },
+            "BugReviewId": {
+                "type": "string",
+                "pattern": "^bfrv_.*"
+            },
+            "RepoId": {
+                "type": "string",
+                "pattern": "^repo_.*"
+            },
+            "OrgId": {
+                "type": "string",
+                "pattern": "^org_.*"
+            },
             "BugReviewState": {
                 "type": "string",
                 "enum": [
@@ -41,7 +57,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/BugReviewId"
                     },
                     "state": {
                         "$ref": "#/components/schemas/BugReviewState"
@@ -66,7 +82,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/BugId"
                     },
                     "title": {
                         "type": "string"
@@ -84,7 +100,7 @@
                         "$ref": "#/components/schemas/BugReview"
                     },
                     "repoId": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/RepoId"
                     },
                     "commitSha": {
                         "type": "string"
@@ -105,7 +121,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/OrgId"
                     },
                     "name": {
                         "type": "string"
@@ -120,7 +136,7 @@
                 "type": "object",
                 "properties": {
                     "id": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/RepoId"
                     },
                     "name": {
                         "type": "string"
@@ -138,7 +154,7 @@
                         "type": "string"
                     },
                     "orgId": {
-                        "type": "string"
+                        "$ref": "#/components/schemas/OrgId"
                     },
                     "orgName": {
                         "type": "string"
@@ -165,7 +181,9 @@
                             "DETAIL_AUTHENTICATION_ERROR",
                             "AUTHORIZATION_ERROR",
                             "NOT_FOUND",
-                            "INTERNAL_ERROR"
+                            "INTERNAL_ERROR",
+                            "INVALID_REQUEST_BODY",
+                            "INVALID_QUERY_PARAMS"
                         ]
                     },
                     "message": {
@@ -179,6 +197,9 @@
                     },
                     "resource": {
                         "type": "string"
+                    },
+                    "details": {
+                        "type": "object"
                     }
                 },
                 "required": [
@@ -206,7 +227,7 @@
                         "in": "query",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/RepoId"
                         }
                     },
                     {
@@ -304,7 +325,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/BugId"
                         }
                     }
                 ],
@@ -358,7 +379,7 @@
                         "in": "path",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "$ref": "#/components/schemas/BugId"
                         }
                     }
                 ],

--- a/src/api/client.rs
+++ b/src/api/client.rs
@@ -41,7 +41,7 @@ impl ApiClient {
 
     pub async fn list_bugs(
         &self,
-        repo_id: &str,
+        repo_id: &RepoId,
         status: BugReviewState,
         limit: u32,
         offset: u32,
@@ -60,7 +60,7 @@ impl ApiClient {
             .map_err(|e| anyhow::anyhow!("API error: {}", e))
     }
 
-    pub async fn get_bug(&self, bug_id: &str) -> Result<Bug> {
+    pub async fn get_bug(&self, bug_id: &BugId) -> Result<Bug> {
         self.inner
             .get_public_bug(bug_id)
             .await
@@ -70,7 +70,7 @@ impl ApiClient {
 
     pub async fn update_bug_close(
         &self,
-        bug_id: &str,
+        bug_id: &BugId,
         state: BugReviewState,
         dismissal_reason: Option<BugDismissalReason>,
         notes: Option<&str>,

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -1,6 +1,7 @@
 // Re-export generated types as the public API for this crate.
 pub use super::generated::types::{
-    Bug, BugDismissalReason, BugReview, BugReviewState, CreatePublicBugReviewBody, Org, Repo,
+    Bug, BugDismissalReason, BugId, BugReview, BugReviewId, BugReviewState,
+    CreatePublicBugReviewBody, Org, OrgId, Repo, RepoId,
 };
 
 // Friendlier aliases for the generated response-wrapper names.
@@ -69,7 +70,7 @@ impl crate::output::Formattable for Bug {
 
     fn to_csv_row(&self) -> Vec<String> {
         vec![
-            self.id.clone(),
+            self.id.to_string(),
             self.title.clone(),
             self.file_path.as_deref().unwrap_or("-").to_string(),
             crate::utils::format_date(self.created_at),
@@ -80,7 +81,7 @@ impl crate::output::Formattable for Bug {
         (
             self.title.clone(),
             vec![
-                ("Bug ID", self.id.clone()),
+                ("Bug ID", self.id.to_string()),
                 ("Created", crate::utils::format_date(self.created_at)),
             ],
         )


### PR DESCRIPTION
Update vendored openapi.json to use named $ref schemas (BugId, RepoId,
OrgId, BugReviewId) with pattern validation instead of plain strings.
Progenitor now generates shared newtype wrappers for all ID fields.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>