### PR TITLE
refactor: remove CSV output format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -531,27 +531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde_core",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,7 +562,6 @@ dependencies = [
  "clap",
  "clap-markdown",
  "console 0.16.2",
- "csv",
  "dialoguer",
  "homedir",
  "progenitor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-csv = "1.4"
 
 # Generated API client
 progenitor = "0.12.0"

--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -124,7 +124,7 @@ List bugs for a given repository
 
   Default value: `table`
 
-  Possible values: `table`, `json`, `csv`
+  Possible values: `table`, `json`
 
 
 
@@ -195,7 +195,7 @@ List all repositories you have access to
 
   Default value: `table`
 
-  Possible values: `table`, `json`, `csv`
+  Possible values: `table`, `json`
 
 
 

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -69,19 +69,6 @@ impl clap::ValueEnum for BugDismissalReason {
 // ── Formattable ──────────────────────────────────────────────────────
 
 impl Formattable for Bug {
-    fn csv_headers() -> &'static [&'static str] {
-        &["id", "title", "file", "created"]
-    }
-
-    fn to_csv_row(&self) -> Vec<String> {
-        vec![
-            self.id.to_string(),
-            self.title.clone(),
-            self.file_path.as_deref().unwrap_or("-").to_string(),
-            format_date(self.created_at),
-        ]
-    }
-
     fn to_card(&self) -> (String, Vec<(&'static str, String)>) {
         (
             self.title.clone(),
@@ -94,14 +81,6 @@ impl Formattable for Bug {
 }
 
 impl Formattable for Repo {
-    fn csv_headers() -> &'static [&'static str] {
-        &["repository", "organization"]
-    }
-
-    fn to_csv_row(&self) -> Vec<String> {
-        vec![self.full_name.clone(), self.org_name.clone()]
-    }
-
     fn to_card(&self) -> (String, Vec<(&'static str, String)>) {
         (
             self.full_name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ impl Cli {
 pub enum OutputFormat {
     Table,
     Json,
-    Csv,
 }
 
 #[derive(Subcommand)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,7 +1,7 @@
 //! CLI output formatting utilities
 
 use std::fmt::Display;
-use std::io::{self, Write as _};
+use std::io::Write as _;
 use std::sync::LazyLock;
 
 use anyhow::Result;
@@ -101,12 +101,6 @@ impl SectionRenderer {
 
 /// Trait for types that can be formatted for list output
 pub trait Formattable {
-    /// Column headers for CSV output
-    fn csv_headers() -> &'static [&'static str];
-
-    /// Convert this item to a CSV row
-    fn to_csv_row(&self) -> Vec<String>;
-
     /// Return a card header and key-value pairs for terminal list display
     fn to_card(&self) -> (String, Vec<(&'static str, String)>);
 }
@@ -130,15 +124,6 @@ pub fn output_list<T: Formattable + Serialize>(
                 "total_pages": total_pages,
             });
             Term::stdout().write_line(&serde_json::to_string_pretty(&response)?)?;
-        }
-        crate::OutputFormat::Csv => {
-            use csv::Writer;
-            let mut wtr = Writer::from_writer(io::stdout());
-            wtr.write_record(T::csv_headers())?;
-            for item in items {
-                wtr.write_record(item.to_csv_row())?;
-            }
-            wtr.flush()?;
         }
         crate::OutputFormat::Table => {
             let term = Term::stdout();


### PR DESCRIPTION
lint: enforce `clippy::absolute_paths` and fix all violations

Add `clippy::absolute_paths` to the deny list in `src/lib.rs` and
replace all 45 inline fully-qualified paths with `use` imports across
10 files.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

refactor: remove CSV output format

Drop the `csv` dependency and the `Csv` variant from `OutputFormat`.
JSON and Table remain as the two supported output formats.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>