### PR TITLE
test: add unit tests for config storage

### DIFF
--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -76,3 +76,131 @@ pub fn clear_credentials() -> Result<()> {
     save_config(&config)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// Mutex to serialize tests that modify the XDG_CONFIG_HOME env var.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run a closure with XDG_CONFIG_HOME pointing to a fresh temp directory,
+    /// restoring the original value afterwards.
+    fn with_temp_config<F: FnOnce() -> R, R>(f: F) -> R {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = env::temp_dir().join(format!("detail-cli-test-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir); // clean slate
+        let prev = env::var("XDG_CONFIG_HOME").ok();
+        env::set_var("XDG_CONFIG_HOME", &dir);
+
+        let result = f();
+
+        // Restore
+        match prev {
+            Some(v) => env::set_var("XDG_CONFIG_HOME", v),
+            None => env::remove_var("XDG_CONFIG_HOME"),
+        }
+        let _ = fs::remove_dir_all(&dir);
+        result
+    }
+
+    // ── Config TOML round-trip ───────────────────────────────────────
+
+    #[test]
+    fn config_default_serializes_to_toml() {
+        let config = Config::default();
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        assert!(toml_str.contains("check_for_updates = false"));
+    }
+
+    #[test]
+    fn config_round_trip_via_toml() {
+        let config = Config {
+            api_url: Some("https://api.example.com".into()),
+            check_for_updates: true,
+            last_update_check: Some(12345),
+            api_token: Some("dtl_test_token".into()),
+        };
+        let toml_str = toml::to_string_pretty(&config).unwrap();
+        let restored: Config = toml::from_str(&toml_str).unwrap();
+        assert_eq!(restored.api_url.as_deref(), Some("https://api.example.com"));
+        assert!(restored.check_for_updates);
+        assert_eq!(restored.last_update_check, Some(12345));
+        assert_eq!(restored.api_token.as_deref(), Some("dtl_test_token"));
+    }
+
+    #[test]
+    fn config_missing_optional_fields_parse_as_none() {
+        let toml_str = "check_for_updates = true\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.api_url.is_none());
+        assert!(config.api_token.is_none());
+        assert!(config.last_update_check.is_none());
+    }
+
+    // ── config_path ──────────────────────────────────────────────────
+
+    #[test]
+    fn config_path_uses_xdg_config_home() {
+        with_temp_config(|| {
+            let path = config_path().unwrap();
+            assert!(path.ends_with("detail-cli/config.toml"));
+            assert!(path.parent().unwrap().exists());
+        });
+    }
+
+    // ── save / load round-trip ───────────────────────────────────────
+
+    #[test]
+    fn save_then_load_config() {
+        with_temp_config(|| {
+            let config = Config {
+                api_url: Some("https://test.dev".into()),
+                check_for_updates: true,
+                last_update_check: None,
+                api_token: Some("tok".into()),
+            };
+            save_config(&config).unwrap();
+            let loaded = load_config().unwrap();
+            assert_eq!(loaded.api_url.as_deref(), Some("https://test.dev"));
+            assert_eq!(loaded.api_token.as_deref(), Some("tok"));
+        });
+    }
+
+    #[test]
+    fn load_config_returns_defaults_when_no_file() {
+        with_temp_config(|| {
+            let config = load_config().unwrap();
+            assert!(config.check_for_updates);
+            assert!(config.api_token.is_none());
+        });
+    }
+
+    // ── token helpers ────────────────────────────────────────────────
+
+    #[test]
+    fn store_and_load_token() {
+        with_temp_config(|| {
+            store_token("dtl_live_secret").unwrap();
+            assert_eq!(load_token().unwrap(), "dtl_live_secret");
+        });
+    }
+
+    #[test]
+    fn load_token_errors_when_absent() {
+        with_temp_config(|| {
+            assert!(load_token().is_err());
+        });
+    }
+
+    #[test]
+    fn clear_credentials_removes_token() {
+        with_temp_config(|| {
+            store_token("dtl_live_secret").unwrap();
+            clear_credentials().unwrap();
+            assert!(load_token().is_err());
+        });
+    }
+}


### PR DESCRIPTION
Cover Config TOML serialization round-trip, config_path resolution via
XDG_CONFIG_HOME, save/load round-trip, and token store/load/clear
helpers. Uses a mutex-guarded temp directory to isolate env-var tests.

Also fix formatting in api types tests (rustfmt).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>