### PR TITLE
fix: validate --page and --limit to prevent panics on zero values

### DIFF
--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -35,11 +35,11 @@ pub enum BugCommands {
         security: bool,
 
         /// Maximum number of results per page
-        #[arg(long, default_value = "50")]
+        #[arg(long, default_value = "50", value_parser = clap::value_parser!(u32).range(1..))]
         limit: u32,
 
         /// Page number (starts at 1)
-        #[arg(long, default_value = "1")]
+        #[arg(long, default_value = "1", value_parser = clap::value_parser!(u32).range(1..))]
         page: u32,
 
         /// Output format

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -12,11 +12,11 @@ pub enum RepoCommands {
     /// List all repositories you have access to
     List {
         /// Maximum number of results per page
-        #[arg(long, default_value = "50")]
+        #[arg(long, default_value = "50", value_parser = clap::value_parser!(u32).range(1..))]
         limit: u32,
 
         /// Page number (starts at 1)
-        #[arg(long, default_value = "1")]
+        #[arg(long, default_value = "1", value_parser = clap::value_parser!(u32).range(1..))]
         page: u32,
 
         /// Output format
@@ -47,7 +47,7 @@ pub async fn handle(command: &RepoCommands, cli: &crate::Cli) -> Result<()> {
                     let width = term.size().1 as usize;
                     let separator = "─".repeat(width);
 
-                    // Group repos by organization, preserving insertion order
+                    // Group repos by organization, sorted alphabetically
                     let mut by_org: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
                     for repo in &repos.repos {
                         by_org.entry(&repo.org_name).or_default().push(&repo.name);


### PR DESCRIPTION
## Summary
- Add clap value_parser range constraints (1..) for --page and --limit on both bugs list and repos list
- Prevents arithmetic underflow panic on --page 0 and division-by-zero panic on --limit 0
- Fix misleading comment: BTreeMap sorts alphabetically, not by insertion order

## Detail Bugs
- bug_83e35590-fb49-4a1e-9cea-8e0b963f0614: bugs list crashes on --page 0 or --limit 0
- bug_1afdfe3c-8f74-4f49-8e3d-d938b8145581: repos list crashes on --limit 0 / --page 0

## Test plan
- [x] cargo clippy and cargo test pass
- [x] --page 0 and --limit 0 now rejected by clap with helpful error