### PR TITLE
fix: harden config file security and forward compatibility

### DIFF
--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -51,7 +51,28 @@ pub fn load_config() -> Result<Config> {
 pub fn save_config(config: &Config) -> Result<()> {
     let path = config_path()?;
     let contents = toml::to_string_pretty(config)?;
-    fs::write(path, contents)?;
+    write_private(path, contents.as_bytes())?;
+    Ok(())
+}
+
+/// Write `data` to `path`, restricting the file to owner-only access (0600) on Unix.
+fn write_private(path: PathBuf, data: &[u8]) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt as _;
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.write_all(data)?;
+    }
+    #[cfg(not(unix))]
+    {
+        fs::write(path, data)?;
+    }
     Ok(())
 }
 
@@ -201,6 +222,18 @@ mod tests {
             store_token("dtl_live_secret").unwrap();
             clear_credentials().unwrap();
             assert!(load_token().is_err());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt as _;
+        with_temp_config(|| {
+            store_token("dtl_live_secret").unwrap();
+            let path = config_path().unwrap();
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "config file should be owner-only (0600)");
         });
     }
 }


### PR DESCRIPTION
## Summary
- Set file permissions to 0600 (owner-only) on Unix when writing config.toml
- Prevents other users on shared systems from reading stored API tokens

## Detail Bugs
- bug_aaa019bb-9dcf-4c2f-a162-a2d3d20709c7: Config file storing API token is created world-readable (security)

## Test plan
- [x] cargo clippy and cargo test pass
- [x] New test verifies 0600 permissions on written config file