### PR TITLE
fix: remove auth login auto-submit to prevent input buffer leak

### DIFF
--- a/src/commands/auth.rs
+++ b/src/commands/auth.rs
@@ -30,18 +30,13 @@ pub async fn handle(command: &AuthCommands, cli: &crate::Cli) -> Result<()> {
                     let term = Term::stdout();
                     term.write_str("Paste your API token: ")?;
 
-                    // Read character-by-character (hidden) and auto-submit
-                    // when a complete token is detected
+                    // Read character-by-character (hidden) until Enter is pressed.
                     let mut token = String::new();
                     loop {
                         let key = term.read_key()?;
                         match key {
                             Key::Char(c) if !c.is_whitespace() => {
                                 token.push(c);
-                                if is_complete_token(&token) {
-                                    term.write_line("")?;
-                                    break;
-                                }
                             }
                             Key::Enter => {
                                 term.write_line("")?;
@@ -124,7 +119,8 @@ pub async fn handle(command: &AuthCommands, cli: &crate::Cli) -> Result<()> {
 }
 
 /// Check if the string matches the expected API token format: dtl_{env}_{32hex}.{64hex}
-pub(crate) fn is_complete_token(s: &str) -> bool {
+#[cfg(test)]
+fn is_complete_token(s: &str) -> bool {
     if !s.starts_with("dtl_") {
         return false;
     }


### PR DESCRIPTION
The interactive token input loop previously auto-submitted when
is_complete_token() detected a valid token, without consuming remaining
characters in the terminal buffer. If a user pasted a string containing
a token followed by additional text, those trailing characters would be
left in stdin and executed by the user's shell after the CLI exited.

Remove auto-submit and require the user to press Enter to submit,
ensuring all pasted input is consumed by the CLI.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>