### PR TITLE
chore: cut a new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 
 [[package]]
 name = "detail-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detail-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Detail Team <eng@detail.dev>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.6 to 0.1.7 in Cargo.toml and Cargo.lock