### PR TITLE
chore: align openapi schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -113,7 +113,8 @@
                         "type": "string"
                     },
                     "filePath": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "createdAt": {
                         "type": "integer"
@@ -125,10 +126,12 @@
                         "$ref": "#/components/schemas/RepoId"
                     },
                     "commitSha": {
-                        "type": "string"
+                        "type": "string",
+                        "nullable": true
                     },
                     "isSecurityVulnerability": {
-                        "type": "boolean"
+                        "type": "boolean",
+                        "nullable": true
                     },
                     "introducedIn": {
                         "$ref": "#/components/schemas/IntroducedIn"


### PR DESCRIPTION
## Summary
- Sync `openapi.json` with latest upstream spec after usedetail/detail#8340 deployed
- `filePath`, `commitSha`, and `isSecurityVulnerability` fields on the `Bug` schema are now `nullable: true`

## Test plan
- [x] `cargo build` compiles cleanly
- [x] All 108 tests pass (`cargo test`)
- [x] `make generate` produces no additional diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
