### PR TITLE
refactor: make IntroducedIn.date required to match backend #8301

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -84,18 +84,19 @@
                     "sha": {
                         "type": "string"
                     },
-                    "prNumber": {
-                        "type": "integer"
+                    "date": {
+                        "type": "string"
                     },
                     "author": {
                         "type": "string"
                     },
-                    "date": {
-                        "type": "string"
+                    "prNumber": {
+                        "type": "integer"
                     }
                 },
                 "required": [
-                    "sha"
+                    "sha",
+                    "date"
                 ]
             },
             "Bug": {

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -36,11 +36,7 @@ fn format_introduced_in(intro: &IntroducedIn) -> String {
         Some(pr) => format!("PR #{} ({})", pr, commit),
         None => commit.to_string(),
     };
-    let date_part = intro
-        .date
-        .as_deref()
-        .map(|d| format!(" on {}", d))
-        .unwrap_or_default();
+    let date_part = format!(" on {}", intro.date);
     let author_part = intro
         .author
         .as_deref()


### PR DESCRIPTION
Align CLI OpenAPI spec with the backend change in det-979 that makes
IntroducedIn.date a required field. Reorder properties to match the
backend spec (sha, date, author, prNumber). Update format_introduced_in
to use date directly instead of treating it as optional.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/115" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
