### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -55,7 +55,7 @@ Common workflow:
 * `repos` — Manage repos tracked with Detail
 * `scans` — List and inspect scans
 * `skill` — Install Detail skills (default: detail-bugs)
-* `update` — Update Immediately (auto-update also runs in the background)
+* `update` — Update immediately (auto-update also runs in the background)
 * `version` — Show version information
 
 
@@ -442,7 +442,7 @@ Install the detail-create-rules skill
 
 ## `detail update`
 
-Update Immediately (auto-update also runs in the background)
+Update immediately (auto-update also runs in the background)
 
 **Usage:** `detail update`
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ enum Commands {
         command: Option<commands::skill::SkillCommands>,
     },
 
-    /// Update Immediately (auto-update also runs in the background)
+    /// Update immediately (auto-update also runs in the background)
     Update,
 
     /// Show version information

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,22 +52,25 @@ impl Cli {
         match &self.command {
             Commands::Bugs { command } => match command {
                 commands::bugs::BugCommands::List { format, .. } => Self::is_json(format),
-                _ => false,
+                commands::bugs::BugCommands::Show { .. }
+                | commands::bugs::BugCommands::Close { .. } => false,
             },
             Commands::Repos { command } => match command {
                 commands::repos::RepoCommands::List { format, .. } => Self::is_json(format),
-                _ => false,
             },
             Commands::Scans { command } => match command {
                 commands::scans::ScanCommands::List { format, .. } => Self::is_json(format),
-                _ => false,
             },
             Commands::Rules { command } => match command {
-                commands::rules::RuleCommands::List { format, .. } => Self::is_json(format),
-                commands::rules::RuleCommands::Requests(
+                commands::rules::RuleCommands::List { format, .. }
+                | commands::rules::RuleCommands::Requests(
                     commands::rules::RuleRequestCommands::List { format, .. },
                 ) => Self::is_json(format),
-                _ => false,
+                commands::rules::RuleCommands::Create { .. }
+                | commands::rules::RuleCommands::Propose { .. }
+                | commands::rules::RuleCommands::Requests(_)
+                | commands::rules::RuleCommands::Show { .. }
+                | commands::rules::RuleCommands::Pull { .. } => false,
             },
             Commands::Auth { .. }
             | Commands::Completions

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,44 +41,34 @@ impl Cli {
         api::client::ApiClient::new(config.api_url, Some(token))
     }
 
+    const fn is_json(format: &OutputFormat) -> bool {
+        matches!(format, OutputFormat::Json)
+    }
+
     /// Returns true when machine-readable output is requested (e.g. `--format json`),
     /// meaning non-essential messages (update notices, progress) should be suppressed
     /// to avoid corrupting structured output.
     const fn is_silent(&self) -> bool {
         match &self.command {
-            Commands::Bugs { command } => matches!(
-                command,
-                commands::bugs::BugCommands::List {
-                    format: OutputFormat::Json,
-                    ..
-                }
-            ),
-            Commands::Repos { command } => matches!(
-                command,
-                commands::repos::RepoCommands::List {
-                    format: OutputFormat::Json,
-                    ..
-                }
-            ),
-            Commands::Scans { command } => matches!(
-                command,
-                commands::scans::ScanCommands::List {
-                    format: OutputFormat::Json,
-                    ..
-                }
-            ),
-            Commands::Rules { command } => matches!(
-                command,
-                commands::rules::RuleCommands::List {
-                    format: OutputFormat::Json,
-                    ..
-                } | commands::rules::RuleCommands::Requests(
-                    commands::rules::RuleRequestCommands::List {
-                        format: OutputFormat::Json,
-                        ..
-                    }
-                )
-            ),
+            Commands::Bugs { command } => match command {
+                commands::bugs::BugCommands::List { format, .. } => Self::is_json(format),
+                _ => false,
+            },
+            Commands::Repos { command } => match command {
+                commands::repos::RepoCommands::List { format, .. } => Self::is_json(format),
+                _ => false,
+            },
+            Commands::Scans { command } => match command {
+                commands::scans::ScanCommands::List { format, .. } => Self::is_json(format),
+                _ => false,
+            },
+            Commands::Rules { command } => match command {
+                commands::rules::RuleCommands::List { format, .. } => Self::is_json(format),
+                commands::rules::RuleCommands::Requests(
+                    commands::rules::RuleRequestCommands::List { format, .. },
+                ) => Self::is_json(format),
+                _ => false,
+            },
             Commands::Auth { .. }
             | Commands::Completions
             | Commands::SatisfyingSort


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/usedetail/cli/security/quality/ai-findings)._

## Summary

Refactors `is_silent()` in `src/lib.rs` to replace `matches!` macro calls with explicit `match` arms and an `is_json()` helper, addressing two code quality findings:

1. **Extracted `is_json` helper** — Replaces repeated inline `OutputFormat::Json` pattern matching with a shared `const fn is_json(&OutputFormat) -> bool`.
2. **Fixed doc comment casing** — `"Update Immediately"` → `"Update immediately"`; regenerated `docs/HELP.md`.

An additional commit fixes CI failures introduced by the initial refactor:

- Replaced wildcard (`_ => false`) arms with explicit variant patterns for `BugCommands` and `RuleCommands` (`clippy::wildcard_enum_match_arm`).
- Removed unreachable wildcard arms for single-variant enums `RepoCommands` and `ScanCommands`.
- Merged `RuleCommands::List` and `RuleCommands::Requests(List)` arms that had identical bodies (`clippy::match_same_arms`).

## Review & Testing Checklist for Human

- [ ] Verify the `RuleCommands` match in `is_silent()` is correct: the specific `Requests(RuleRequestCommands::List { format, .. })` arm must appear before the catch-all `Requests(_)` arm — confirm ordering in the diff.
- [ ] Confirm no behavioral change: run `cargo test` and check that all `is_silent` / `should_run_auto_update` tests still pass.
- [ ] If new enum variants are added to `BugCommands`, `RuleCommands`, etc. in the future, the compiler will now require updating `is_silent()` — confirm this is the desired behavior vs. defaulting to `false`.

### Notes

- All existing tests pass. No new tests were added since the behavior is unchanged.
- `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo xtask check` all pass locally.

Link to Devin session: https://app.devin.ai/sessions/573359ee8c174c8291889c54c2cb9a4c
Requested by: @sachiniyer
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
