### PR TITLE
ci: add workflow to close PRs inactive for 2+ weeks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Close stale PRs
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-message: "This PR has been inactive for 7 days and will be closed in 7 days if there is no activity."
+          close-pr-message: "Closing this PR due to inactivity. Feel free to reopen if still needed."
+          stale-pr-label: stale
+          exempt-pr-labels: do-not-close
+          operations-per-run: 1000
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/stale.yml` that uses `actions/stale@v9` to close PRs inactive for 14 days (7-day stale warning + 7-day close window).
- Mirrors the `usedetail/detail` stale workflow pattern, scaled from 30 → 14 days.
- PRs labeled `do-not-close` are exempt. Runs daily at 00:00 UTC; also dispatchable manually.

## Test plan
- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm it runs without errors
- [ ] Verify an open PR with no `do-not-close` label and no activity for 7+ days gets the `stale` label and warning comment
- [ ] Verify a PR labeled `do-not-close` is skipped
- [ ] Confirm PRs with activity inside the 14-day window are left alone

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
