### PR TITLE
fix: vendor updated openapi.json so BugSource accepts new backend variants

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -177,7 +177,10 @@
       "BugSource": {
         "enum": [
           "review",
-          "linear"
+          "linear",
+          "jira",
+          "github_issue",
+          "bug_fix_check"
         ],
         "type": "string"
       },


### PR DESCRIPTION
## Summary
- The backend now emits `review.source` values of `jira`, `github_issue`, and `bug_fix_check` on real bug responses, but the vendored `openapi.json` only declared `review` and `linear`.
- Progenitor's generated `BugSource` enum therefore rejected the actual payload, causing every command that deserializes a review to fail with `Invalid Response Payload: unknown variant 'github_issue'`:
  - `detail bugs list --status resolved`
  - `detail bugs list --status dismissed`
  - `detail bugs list --vulns` / `--introduced-by` (they pull all statuses internally)
  - `detail bugs show <bug_id>` against any review-bearing bug
- Ran `cargo xtask generate-openapi` to pull the updated spec from `https://api.detail.dev/public/v1/openapi.json`. The only delta is the three new `BugSource` variants; progenitor will regenerate the matching Rust enum on build.

## Test plan
- [x] `cargo build` succeeds (progenitor regenerates `BugSource` with the new variants)
- [x] `cargo run -- bugs list usedetail/cli --status resolved --format json` now returns valid JSON instead of `Failed to fetch bugs from repository`
- [x] `cargo run -- bugs list usedetail/cli --status dismissed --format json` same
- [ ] CI integration tests (which exercise `bugs_list_all_statuses` against the live API) go green

## Customer impact
The current 0.2.0 release is broken for any repo with reviews sourced from the new backend integrations. Recommend cutting a patch release after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/255" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
