### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "detail-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "detail-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Detail Team <eng@detail.dev>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Patch release shipping #255, which unbreaks `bugs list --status resolved|dismissed` and `bugs show` for reviews sourced from the backend's new `jira`, `github_issue`, and `bug_fix_check` integrations.

On merge, the release workflow will tag `v0.2.1` and publish platform artifacts via cargo-dist.

## Test plan
- [x] `cargo build` succeeds with version 0.2.1
- [ ] Tag `v0.2.1` is created on merge and release workflow publishes artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
