### PR TITLE
refactor(config): rewrite update_config through the locked handle

### DIFF
--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::io::{ErrorKind, Read as _, Write as _};
+use std::io::{ErrorKind, Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::PathBuf;
 use std::{env, fs};
 
@@ -95,7 +95,12 @@ pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     f(&mut config);
 
     let new_contents = toml::to_string_pretty(&config)?;
-    let file = File::create(&path)?;
+    // Rewrite through the same handle. `File::create` would open a second
+    // file description and leave `file.unlock()` acting on a handle that was
+    // never locked — functionally OK because the real unlock still happens
+    // via Drop at end of scope, but confusing to read.
+    (&file).seek(SeekFrom::Start(0))?;
+    file.set_len(0)?;
     (&file).write_all(new_contents.as_bytes())?;
     file.unlock()?;
     Ok(())


### PR DESCRIPTION
## Summary
- `update_config` opened a second `File::create` handle to truncate and write the config, which made `file.unlock()` act on a handle that was never locked. The real lock release happened via `Drop` at end of scope — functionally correct but confusing, and it matched the shape of the race described in bug_e79362bd / #229.
- Rewind, truncate in place (`set_len(0)`), and write through the already-locked handle. `file.unlock()` now releases the lock that was actually acquired.

## Why this is a refactor, not a bug fix
The linked bug claimed the shadowed handle drops early, releasing the flock mid-write. It does not — Rust shadowing keeps the old binding alive until end of scope. I verified with a subprocess `flock -n` test that the lock is still held after the shadow. The bug report's failing test most likely picked up the tiny artifact between function return (Drop releases the flock) and the main thread flipping its "in-update" flag to false, not a real mid-write unlock.

No behavior change; existing `concurrent_update_config_does_not_corrupt` still passes.

## Test plan
- [x] `cargo test --lib config::storage` — 15 pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/257" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
