### PR TITLE
fix(git): parse GitHub remotes with embedded http(s) credentials

### DIFF
--- a/src/utils/git.rs
+++ b/src/utils/git.rs
@@ -14,11 +14,35 @@ fn parse_github_remote_url(url: &str) -> Option<String> {
         "ssh://git@github.com/",
     ];
 
+    // Git accepts HTTPS remotes with embedded credentials
+    // (https://token@github.com/…, https://user:pass@github.com/…).
+    // Normalize to the un-credentialed form before prefix matching.
+    let normalized = strip_http_credentials(url);
+    let url = normalized.as_deref().unwrap_or(url);
+
     let rest = PREFIXES.iter().find_map(|p| url.strip_prefix(p))?;
     let rest = rest.trim_end_matches('/').trim_end_matches(".git");
     let parts: Vec<&str> = rest.splitn(3, '/').collect();
     (parts.len() >= 2 && !parts[0].is_empty() && !parts[1].is_empty())
         .then(|| format!("{}/{}", parts[0], parts[1]))
+}
+
+/// If `url` is an http(s) URL with `user[:pass]@` credentials in the authority,
+/// return the URL with those credentials stripped. Returns `None` for URLs
+/// without credentials or with non-http(s) schemes.
+fn strip_http_credentials(url: &str) -> Option<String> {
+    for scheme in ["https://", "http://"] {
+        if let Some(rest) = url.strip_prefix(scheme) {
+            // Credentials live in the authority, which runs up to the first `/`
+            // (or end of string). Anything after the authority — including a
+            // `@` in the path — stays untouched.
+            let (authority, path) = rest.split_once('/').unwrap_or((rest, ""));
+            if let Some((_, host)) = authority.split_once('@') {
+                return Some(format!("{scheme}{host}/{path}"));
+            }
+        }
+    }
+    None
 }
 
 /// Infer the `owner/repo` identifier from the current git repository by
@@ -162,6 +186,49 @@ mod tests {
         assert_eq!(
             parse_github_remote_url("https://github.com/owner/repo/tree/main"),
             Some("owner/repo".to_string()),
+        );
+    }
+
+    #[test]
+    fn parses_https_with_token_credentials() {
+        assert_eq!(
+            parse_github_remote_url("https://token@github.com/usedetail/cli.git"),
+            Some("usedetail/cli".to_string()),
+        );
+    }
+
+    #[test]
+    fn parses_https_with_user_pass_credentials() {
+        assert_eq!(
+            parse_github_remote_url("https://user:pass@github.com/usedetail/cli.git"),
+            Some("usedetail/cli".to_string()),
+        );
+    }
+
+    #[test]
+    fn parses_http_with_credentials() {
+        assert_eq!(
+            parse_github_remote_url("http://user:pass@github.com/owner/repo"),
+            Some("owner/repo".to_string()),
+        );
+    }
+
+    #[test]
+    fn leaves_at_in_path_untouched() {
+        // An `@` after the first `/` is part of the path, not credentials.
+        assert_eq!(
+            parse_github_remote_url("https://github.com/owner/repo@tag"),
+            // Trailing `@tag` is treated as part of the repo name; gets trimmed
+            // along with anything after owner/repo.
+            Some("owner/repo@tag".to_string()),
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_host_even_with_credentials() {
+        assert_eq!(
+            parse_github_remote_url("https://token@gitlab.com/owner/repo.git"),
+            None,
         );
     }
 


### PR DESCRIPTION
## Summary
`parse_github_remote_url` used strict `strip_prefix` matches against `https://github.com/`. Valid remotes of the form `https://token@github.com/owner/repo.git` or `https://user:pass@github.com/owner/repo.git` — which git itself accepts and stores — fell through and returned `None`, breaking repo auto-inference for anyone using a credential-embedded remote.

Normalize http(s) URLs by stripping the `user[:pass]@` portion of the authority before the prefix check. The strip is scoped to characters before the first `/`, so a literal `@` in the path (e.g. `.../repo@tag`) is left alone. SSH forms (`git@github.com:…`, `ssh://git@github.com/…`) are unaffected.

## Test plan
- [x] `cargo test --lib utils::git` — 20 pass, including 5 new cases (token creds, user:pass creds, http scheme, `@` in path, non-github host with creds)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Fixes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
