### PR TITLE
fix(repos): normalize whitespace in repo identifiers before lookup

### DIFF
--- a/src/utils/repos.rs
+++ b/src/utils/repos.rs
@@ -74,17 +74,27 @@ pub async fn resolve_repo_id(client: &ApiClient, repo_identifier: &str) -> Resul
 }
 
 pub fn resolve_repo_id_from_repos(repos: &[Repo], repo_identifier: &str) -> Result<RepoId> {
-    if repo_identifier.contains('/') {
-        validate_owner_repo_format(repo_identifier)?;
+    // Normalize accidental whitespace before matching. `validate_owner_repo_format`
+    // already tolerated whitespace-only emptiness checks but the original input
+    // was then compared verbatim against `r.full_name`, producing a misleading
+    // "not found" error for inputs like " usedetail/cli".
+    let identifier = repo_identifier.trim();
+    if identifier.contains('/') {
+        validate_owner_repo_format(identifier)?;
+        let normalized = identifier
+            .split('/')
+            .map(str::trim)
+            .collect::<Vec<_>>()
+            .join("/");
         repos
             .iter()
-            .find(|r| r.full_name == repo_identifier)
+            .find(|r| r.full_name == normalized)
             .map(|r| r.id.clone())
             .context(format!(
-                "Repository '{repo_identifier}' not found. Make sure you have access to this repository."
+                "Repository '{normalized}' not found. Make sure you have access to this repository."
             ))
     } else {
-        match_repo_by_name(repo_identifier, repos)
+        match_repo_by_name(identifier, repos)
     }
 }
 
@@ -234,5 +244,36 @@ mod tests {
         let repos = sample_repos();
         let err = resolve_repo_id_from_repos(&repos, "cli").unwrap_err();
         assert!(err.to_string().contains("Multiple repositories"));
+    }
+
+    #[test]
+    fn resolve_owner_repo_trims_surrounding_whitespace() {
+        let repos = sample_repos();
+        let id = resolve_repo_id_from_repos(&repos, "  usedetail/cli  ").unwrap();
+        assert_eq!(id.to_string(), "repo_1");
+    }
+
+    #[test]
+    fn resolve_owner_repo_trims_around_slash() {
+        let repos = sample_repos();
+        let id = resolve_repo_id_from_repos(&repos, "usedetail / cli").unwrap();
+        assert_eq!(id.to_string(), "repo_1");
+    }
+
+    #[test]
+    fn resolve_bare_name_trims_whitespace() {
+        let repos = sample_repos();
+        let id = resolve_repo_id_from_repos(&repos, "  web  ").unwrap();
+        assert_eq!(id.to_string(), "repo_3");
+    }
+
+    #[test]
+    fn resolve_owner_repo_not_found_error_uses_normalized_form() {
+        // The "not found" hint should quote the cleaned identifier, not the
+        // raw whitespace-padded input.
+        let repos = sample_repos();
+        let err = resolve_repo_id_from_repos(&repos, "  usedetail/missing  ").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'usedetail/missing'"), "got: {msg}");
     }
 }


### PR DESCRIPTION
## Summary
Inputs like `' usedetail/cli'` or `'usedetail / cli'` passed `validate_owner_repo_format` (which used `.trim().is_empty()` only for emptiness checks) but were then compared verbatim against `r.full_name`. The exact match failed and users got a misleading **"Repository not found. Make sure you have access …"** error for what was actually a whitespace typo.

Trim the identifier, and trim each half of an `owner/repo` pair, before matching. The "not found" error now quotes the normalized form so the hint itself is accurate.

## Stacked on
**#260** (fix for GitHub remote parsing with embedded credentials). Base branch is `siyer/fix-parse-github-remote-creds`; the diff against main is just the repos.rs change.

## Test plan
- [x] `cargo test --lib utils::repos` — 22 pass, including 4 new cases (leading/trailing whitespace, whitespace around slash, bare-name trim, normalized error message)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Fixes #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
