### PR TITLE
fix(datetime): floor sub-second negative timestamps instead of snapping to epoch

### DIFF
--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -1,11 +1,11 @@
 use chrono::Local;
 
-/// Conversion factor from milliseconds to seconds
-const MS_TO_SECONDS: i64 = 1000;
-
 /// Format a UTC timestamp (in milliseconds) in the machine's local timezone.
 fn format_timestamp(timestamp_ms: i64, fmt: &str) -> String {
-    chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0).map_or_else(
+    // `from_timestamp_millis` floors toward negative infinity, so timestamps
+    // in (-1000, 0) correctly land in the second before the epoch instead of
+    // collapsing to epoch via integer-division truncation.
+    chrono::DateTime::from_timestamp_millis(timestamp_ms).map_or_else(
         || "-".into(),
         |dt| dt.with_timezone(&Local).format(fmt).to_string(),
     )
@@ -26,7 +26,7 @@ mod tests {
     use super::*;
 
     fn expected_local(timestamp_ms: i64, fmt: &str) -> String {
-        chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0)
+        chrono::DateTime::from_timestamp_millis(timestamp_ms)
             .expect("valid timestamp")
             .with_timezone(&Local)
             .format(fmt)
@@ -74,5 +74,13 @@ mod tests {
             format_datetime(500),
             expected_local(500, "%Y-%m-%d %H:%M:%S %Z")
         );
+    }
+
+    #[test]
+    fn format_datetime_small_negative_is_not_epoch() {
+        // Timestamps in (-1000, 0) ms should land in the second *before* the
+        // epoch, not at the epoch itself. Integer-division truncation toward
+        // zero previously collapsed this whole window onto 1970-01-01 00:00:00.
+        assert_ne!(format_datetime(-1), format_datetime(0));
     }
 }


### PR DESCRIPTION
## Summary
`format_timestamp` converted `timestamp_ms → seconds` by integer division, which truncates toward zero. Timestamps in the (-1000, 0) ms window therefore collapsed onto the Unix epoch (1970-01-01 00:00:00) instead of formatting as the preceding second (1969-12-31 23:59:59).

Swap `chrono::DateTime::from_timestamp(timestamp_ms / MS_TO_SECONDS, 0)` for `chrono::DateTime::from_timestamp_millis(timestamp_ms)`, which takes millisecond timestamps directly and floors correctly. The `MS_TO_SECONDS` constant is no longer used.

## Test plan
- [x] `cargo test --lib utils::datetime` — 7 pass, including new `format_datetime_small_negative_is_not_epoch` regression test
- [x] Existing positive-path tests (including sub-second `format_datetime_rounds_down_sub_second`) still pass — `from_timestamp_millis` produces the same formatted output for those inputs
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

Fixes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
