### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 for RUSTSEC-2026-0104

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,9 +2194,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
The CI Security Audit step started failing on **[RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104)** — a reachable panic in `rustls-webpki` 0.103.12 when parsing certificate revocation lists (`BorrowedCertRevocationList::from_der` / `OwnedCertRevocationList::from_der`). Patched in 0.103.13.

`rustls-webpki` is a transitive dep pulled in via the TLS stack, so the only change needed is `cargo update -p rustls-webpki`. Cargo.lock only; no source code touched.

## Test plan
- [x] `cargo update -p rustls-webpki` → 0.103.12 → 0.103.13
- [x] `cargo build` clean
- [ ] `Security Audit` CI check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
