### PR TITLE
fix(bugs): print empty-results hint when --vulns alone yields no matches

### DIFF
--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -337,6 +337,16 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                         }
                         return output_list(&filtered, 0, *page, *limit, format);
                     }
+                } else if filtered.is_empty() {
+                    // `--vulns` alone filtered everything out. Without this
+                    // branch the user just sees an empty table and no hint,
+                    // even though `empty_filter_hint` already has the right
+                    // message for this case.
+                    if matches!(format, crate::OutputFormat::Table) {
+                        let hint = empty_filter_hint(&filtered, *vulns);
+                        Term::stdout().write_line(&hint)?;
+                    }
+                    return output_list(&filtered, 0, *page, *limit, format);
                 }
                 let total = filtered.len();
                 let page_items = paginate_items(&filtered, *page, *limit);


### PR DESCRIPTION
## Summary
Follow-up to #254. That PR introduced `empty_filter_hint` with a dedicated *"No security vulnerabilities found with the current filters."* branch — and a unit test (`empty_filter_hint_vulns_flag_with_empty_prefilter`) asserting that exact message — but only wired the helper into the `--introduced-by` branch of the handler. When a user runs `detail bugs list --vulns` without an author filter and zero vulnerabilities match, the helper is never reached: they just see an empty table with no explanation.

Add the matching early return for the `--vulns`-alone case: if the post-`--vulns` filter is empty and `--introduced-by` wasn't given, print the hint and return.

## Test plan
- [x] `cargo test --lib bugs::` — 35 pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: `detail bugs list <repo-without-vulns> --vulns` now prints "No security vulnerabilities found with the current filters." instead of an empty table

Fixes #259.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
