### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,7 +654,7 @@ dependencies = [
 
 [[package]]
 name = "detail-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "detail-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Detail Team <eng@detail.dev>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Patch release rolling up the seven fixes merged since 0.2.1:

- fix(bugs): print empty-results hint when `--vulns` alone yields no matches (#264)
- fix(datetime): floor sub-second negative timestamps instead of snapping to epoch (#262)
- chore(deps): bump rustls-webpki to 0.103.13 for RUSTSEC-2026-0104 (#263)
- fix(repos): normalize whitespace in repo identifiers before lookup (#261)
- fix(git): parse GitHub remotes with embedded http(s) credentials (#260)
- fix(auth): redirect browser and surface OAuth errors on PKCE callback failure (#258)
- refactor(config): rewrite `update_config` through the locked handle (#257)

On merge, the release workflow will tag `v0.2.2` and publish platform artifacts via cargo-dist.

## Test plan
- [x] `cargo build` succeeds with version 0.2.2
- [ ] Tag `v0.2.2` is created on merge and release workflow publishes artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
