### PR TITLE
feat(config): preserve comments and unknown keys in config.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "termimad",
  "tokio",
  "toml",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2763,10 +2764,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.0.0+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -2776,6 +2786,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -3618,6 +3643,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = "1.0"
 
 # Config management
 toml = "1.0"
+toml_edit = { version = "0.23", features = ["serde"] }
 homedir = "0.3"
 fs2 = "0.4"
 

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{ErrorKind, Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::PathBuf;
@@ -6,6 +7,8 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use toml_edit::DocumentMut;
+use toml_edit::ser::to_document;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -73,6 +76,12 @@ pub fn save_config(config: &Config) -> Result<()> {
 }
 
 /// Atomically read-modify-write the config file under an exclusive lock.
+///
+/// Preserves comments and formatting the user may have added by hand: the
+/// file is parsed as a `toml_edit::DocumentMut`, the mutated `Config` is
+/// merged back key-by-key, and assigning through `doc[key] = …` keeps the
+/// decor (including `# …` lines above each key) intact. Unknown keys the
+/// user wrote are left untouched.
 pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     let path = config_path()?;
     let file = File::options()
@@ -86,15 +95,41 @@ pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     let mut contents = String::new();
     (&file).read_to_string(&mut contents)?;
 
+    let mut doc: DocumentMut = if contents.is_empty() {
+        DocumentMut::new()
+    } else {
+        contents.parse().context("Failed to parse config")?
+    };
+
     let mut config: Config = if contents.is_empty() {
         Config::default()
     } else {
         toml::from_str(&contents).context("Failed to parse config")?
     };
 
+    // Snapshot which Config-owned keys exist before the closure runs so we
+    // can drop any whose value transitions Some → None (e.g. logout clearing
+    // `api_token`). Without this step, a field set to `None` would silently
+    // linger in the file because TOML serialization simply omits it.
+    let old_keys: BTreeSet<String> = to_document(&config)
+        .context("Failed to serialize config")?
+        .iter()
+        .map(|(k, _)| k.to_string())
+        .collect();
+
     f(&mut config);
 
-    let new_contents = toml::to_string_pretty(&config)?;
+    let fresh = to_document(&config).context("Failed to serialize config")?;
+    let new_keys: BTreeSet<String> = fresh.iter().map(|(k, _)| k.to_string()).collect();
+
+    for (key, item) in fresh.iter() {
+        doc[key] = item.clone();
+    }
+    for removed in old_keys.difference(&new_keys) {
+        doc.remove(removed);
+    }
+
+    let new_contents = doc.to_string();
     // Rewrite through the same handle. `File::create` would open a second
     // file description and leave `file.unlock()` acting on a handle that was
     // never locked — functionally OK because the real unlock still happens
@@ -343,6 +378,59 @@ mod tests {
             // After drop, another acquire should succeed
             let lock = try_acquire_update_lock().unwrap();
             assert!(lock.is_some());
+        });
+    }
+
+    // ── comment preservation ─────────────────────────────────────────
+
+    #[test]
+    fn update_config_preserves_comments_and_unknown_keys() {
+        with_temp_config(|| {
+            let path = config_path().unwrap();
+            let seeded = "\
+# Detail CLI config
+# hand-edited — do not overwrite comments.
+
+# API endpoint override
+api_url = \"https://custom.example.com\"
+
+# Auth token
+api_token = \"old_token\"
+
+# Unknown key the user added
+custom_note = \"leave me alone\"
+";
+            fs::write(&path, seeded).unwrap();
+
+            update_config(|config| {
+                config.api_token = Some("new_token".into());
+            })
+            .unwrap();
+
+            let raw = fs::read_to_string(&path).unwrap();
+            assert!(raw.contains("# Detail CLI config"), "header comment lost:\n{raw}");
+            assert!(raw.contains("# API endpoint override"), "key comment lost:\n{raw}");
+            assert!(raw.contains("# Auth token"), "key comment lost:\n{raw}");
+            assert!(raw.contains("# Unknown key the user added"), "unknown-key comment lost:\n{raw}");
+            assert!(raw.contains("custom_note"), "unknown key dropped:\n{raw}");
+            assert!(raw.contains("\"new_token\""), "update did not land:\n{raw}");
+            assert!(!raw.contains("old_token"), "old value lingered:\n{raw}");
+        });
+    }
+
+    #[test]
+    fn update_config_removes_key_when_field_set_to_none() {
+        with_temp_config(|| {
+            let path = config_path().unwrap();
+            fs::write(&path, "# token below\napi_token = \"to_be_cleared\"\n").unwrap();
+
+            update_config(|config| {
+                config.api_token = None;
+            })
+            .unwrap();
+
+            let raw = fs::read_to_string(&path).unwrap();
+            assert!(!raw.contains("api_token"), "cleared field still present:\n{raw}");
         });
     }
 

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::fs::File;
 use std::io::{ErrorKind, Read as _, Seek as _, SeekFrom, Write as _};
 use std::path::PathBuf;
@@ -77,11 +76,12 @@ pub fn save_config(config: &Config) -> Result<()> {
 
 /// Atomically read-modify-write the config file under an exclusive lock.
 ///
-/// Preserves comments and formatting the user may have added by hand: the
-/// file is parsed as a `toml_edit::DocumentMut`, the mutated `Config` is
-/// merged back key-by-key, and assigning through `doc[key] = …` keeps the
-/// decor (including `# …` lines above each key) intact. Unknown keys the
-/// user wrote are left untouched.
+/// Preserves comments and formatting the user may have added by hand. The
+/// file is parsed as a `toml_edit::DocumentMut`; we snapshot the typed
+/// `Config` before and after the closure and only touch keys whose value
+/// actually changed. That keeps line comments above each key, trailing
+/// inline comments, and the user's chosen quote style intact for fields
+/// the update didn't care about — and leaves unknown user-added keys alone.
 pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     let path = config_path()?;
     let file = File::options()
@@ -107,26 +107,20 @@ pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
         toml::from_str(&contents).context("Failed to parse config")?
     };
 
-    // Snapshot which Config-owned keys exist before the closure runs so we
-    // can drop any whose value transitions Some → None (e.g. logout clearing
-    // `api_token`). Without this step, a field set to `None` would silently
-    // linger in the file because TOML serialization simply omits it.
-    let old_keys: BTreeSet<String> = to_document(&config)
-        .context("Failed to serialize config")?
-        .iter()
-        .map(|(k, _)| k.to_string())
-        .collect();
-
+    let before = toml::Table::try_from(&config).context("Failed to serialize config")?;
     f(&mut config);
-
+    let after = toml::Table::try_from(&config).context("Failed to serialize config")?;
     let fresh = to_document(&config).context("Failed to serialize config")?;
-    let new_keys: BTreeSet<String> = fresh.iter().map(|(k, _)| k.to_string()).collect();
 
-    for (key, item) in fresh.iter() {
-        doc[key] = item.clone();
+    for (key, new_value) in &after {
+        if before.get(key) != Some(new_value) {
+            doc[key] = fresh[key].clone();
+        }
     }
-    for removed in old_keys.difference(&new_keys) {
-        doc.remove(removed);
+    for key in before.keys() {
+        if !after.contains_key(key) {
+            doc.remove(key);
+        }
     }
 
     let new_contents = doc.to_string();
@@ -424,6 +418,32 @@ custom_note = \"leave me alone\"
             assert!(raw.contains("custom_note"), "unknown key dropped:\n{raw}");
             assert!(raw.contains("\"new_token\""), "update did not land:\n{raw}");
             assert!(!raw.contains("old_token"), "old value lingered:\n{raw}");
+        });
+    }
+
+    #[test]
+    fn update_config_leaves_unchanged_keys_byte_identical() {
+        with_temp_config(|| {
+            let path = config_path().unwrap();
+            // Trailing inline comment + literal-string quoting are the kinds
+            // of value-level decor that blanket-overwrite would clobber.
+            let seeded = "\
+api_url = 'https://api.staging.detail.dev' # staging override
+api_token = \"old_token\"
+";
+            fs::write(&path, seeded).unwrap();
+
+            update_config(|config| {
+                config.api_token = Some("new_token".into());
+            })
+            .unwrap();
+
+            let raw = fs::read_to_string(&path).unwrap();
+            assert!(
+                raw.contains("'https://api.staging.detail.dev' # staging override"),
+                "untouched key's inline comment + quoting must survive verbatim:\n{raw}"
+            );
+            assert!(raw.contains("\"new_token\""), "update did not land:\n{raw}");
         });
     }
 

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -439,6 +439,33 @@ api_token = \"old_token\"
     }
 
     #[test]
+    fn update_config_on_empty_file_writes_mutated_fields() {
+        with_temp_config(|| {
+            let path = config_path().unwrap();
+            // File is created empty by update_config's `create(true)` + first
+            // read of an empty handle returns "". This locks in that neither
+            // the `DocumentMut` parse nor the `toml::from_str` deserialization
+            // chokes on an empty string — the defensive `if contents.is_empty()`
+            // branch we removed was never actually necessary.
+            assert!(!path.exists(), "precondition: no config file yet");
+
+            update_config(|config| {
+                config.api_token = Some("fresh_token".into());
+            })
+            .unwrap();
+
+            let raw = fs::read_to_string(&path).unwrap();
+            assert!(
+                raw.contains("api_token = \"fresh_token\""),
+                "mutation missing:\n{raw}"
+            );
+
+            let loaded = load_config().unwrap();
+            assert_eq!(loaded.api_token.as_deref(), Some("fresh_token"));
+        });
+    }
+
+    #[test]
     fn update_config_removes_key_when_field_set_to_none() {
         with_temp_config(|| {
             let path = config_path().unwrap();

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -6,6 +6,7 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
+use toml_edit::de::from_document;
 use toml_edit::ser::to_document;
 use toml_edit::DocumentMut;
 
@@ -95,17 +96,8 @@ pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     let mut contents = String::new();
     (&file).read_to_string(&mut contents)?;
 
-    let mut doc: DocumentMut = if contents.is_empty() {
-        DocumentMut::new()
-    } else {
-        contents.parse().context("Failed to parse config")?
-    };
-
-    let mut config: Config = if contents.is_empty() {
-        Config::default()
-    } else {
-        toml::from_str(&contents).context("Failed to parse config")?
-    };
+    let mut doc: DocumentMut = contents.parse().context("Failed to parse config")?;
+    let mut config: Config = from_document(doc.clone()).context("Failed to parse config")?;
 
     let before = toml::Table::try_from(&config).context("Failed to serialize config")?;
     f(&mut config);

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -6,7 +6,6 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
-use toml_edit::de::from_document;
 use toml_edit::ser::to_document;
 use toml_edit::DocumentMut;
 
@@ -97,7 +96,7 @@ pub fn update_config(f: impl FnOnce(&mut Config)) -> Result<()> {
     (&file).read_to_string(&mut contents)?;
 
     let mut doc: DocumentMut = contents.parse().context("Failed to parse config")?;
-    let mut config: Config = from_document(doc.clone()).context("Failed to parse config")?;
+    let mut config: Config = toml::from_str(&contents).context("Failed to parse config")?;
 
     let before = toml::Table::try_from(&config).context("Failed to serialize config")?;
     f(&mut config);

--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -7,8 +7,8 @@ use std::{env, fs};
 use anyhow::{Context, Result};
 use fs2::FileExt;
 use serde::{Deserialize, Serialize};
-use toml_edit::DocumentMut;
 use toml_edit::ser::to_document;
+use toml_edit::DocumentMut;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -408,10 +408,19 @@ custom_note = \"leave me alone\"
             .unwrap();
 
             let raw = fs::read_to_string(&path).unwrap();
-            assert!(raw.contains("# Detail CLI config"), "header comment lost:\n{raw}");
-            assert!(raw.contains("# API endpoint override"), "key comment lost:\n{raw}");
+            assert!(
+                raw.contains("# Detail CLI config"),
+                "header comment lost:\n{raw}"
+            );
+            assert!(
+                raw.contains("# API endpoint override"),
+                "key comment lost:\n{raw}"
+            );
             assert!(raw.contains("# Auth token"), "key comment lost:\n{raw}");
-            assert!(raw.contains("# Unknown key the user added"), "unknown-key comment lost:\n{raw}");
+            assert!(
+                raw.contains("# Unknown key the user added"),
+                "unknown-key comment lost:\n{raw}"
+            );
             assert!(raw.contains("custom_note"), "unknown key dropped:\n{raw}");
             assert!(raw.contains("\"new_token\""), "update did not land:\n{raw}");
             assert!(!raw.contains("old_token"), "old value lingered:\n{raw}");
@@ -430,7 +439,10 @@ custom_note = \"leave me alone\"
             .unwrap();
 
             let raw = fs::read_to_string(&path).unwrap();
-            assert!(!raw.contains("api_token"), "cleared field still present:\n{raw}");
+            assert!(
+                !raw.contains("api_token"),
+                "cleared field still present:\n{raw}"
+            );
         });
     }
 


### PR DESCRIPTION
## Summary
- `update_config` used to round-trip through `toml::to_string_pretty`, which drops every comment and hand-added key in `~/.config/detail-cli/config.toml`. Any login, logout, or update-check write would erase user annotations.
- Route writes through `toml_edit::DocumentMut`: parse the existing file as a document, run the existing closure against a typed `Config`, then merge the mutated struct back key-by-key via `toml_edit::ser::to_document`. `doc[key] = item` preserves the key's decor (line comments above it); keys that go `Some → None` are explicitly removed so `clear_credentials` still strips `api_token`; unknown user keys are left alone.
- Public API (`update_config(|c| ...)`) unchanged — no callers touched. Merge is serde-driven over all `Config` fields, so adding a new field tomorrow requires no edits to `storage.rs`.

## Test plan
- [x] `cargo test --lib` — 235 passing, including two new tests:
  - `update_config_preserves_comments_and_unknown_keys` — seeds a file with header comment, per-key comments, and a `custom_note` key the user "added by hand"; asserts all survive after a token rewrite.
  - `update_config_removes_key_when_field_set_to_none` — confirms logout-style clears still wipe the key from disk.
- [x] `cargo clippy -- -D warnings` (the CI invocation) clean.
- [ ] Manual: add a comment to `config.toml`, run `detail auth login` then `detail auth logout`, confirm comment survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
