### PR TITLE
feat(bugs): add --all flag to bugs list

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -137,6 +137,7 @@ List bugs for a given repository
 * `--vulns` — Only show security vulnerabilities
 * `--introduced-by <INTRODUCED_BY>` — Only show bugs introduced by these authors (comma-separated or repeat flag)
 * `--scan-id <SCAN_ID>` — Filter bugs to a specific scan by workflow request ID
+* `--all` — Auto-paginate: fetch every matching bug instead of a single page
 * `--limit <LIMIT>` — Maximum number of results per page
 
   Default value: `50`

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -124,6 +124,10 @@ pub enum BugCommands {
         #[arg(long)]
         scan_id: Option<String>,
 
+        /// Auto-paginate: fetch every matching bug instead of a single page.
+        #[arg(long, conflicts_with_all = ["page", "limit"])]
+        all: bool,
+
         /// Maximum number of results per page
         #[arg(long, default_value = "50", value_parser = clap::value_parser!(u32).range(1..=100))]
         limit: u32,
@@ -304,6 +308,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
             vulns,
             introduced_by,
             scan_id,
+            all,
             limit,
             page,
             format,
@@ -320,7 +325,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                 .transpose()
                 .context("Invalid scan ID format (expected wr_...)")?;
 
-            if *vulns || !introduced_by.is_empty() {
+            if *all || *vulns || !introduced_by.is_empty() {
                 let all_bugs =
                     fetch_all_bugs(&client, &resolved_repo_id, *status, scan_id.as_ref()).await?;
                 let mut filtered = all_bugs;
@@ -338,10 +343,9 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                         return output_list(&filtered, 0, *page, *limit, format);
                     }
                 } else if filtered.is_empty() {
-                    // `--vulns` alone filtered everything out. Without this
-                    // branch the user just sees an empty table and no hint,
-                    // even though `empty_filter_hint` already has the right
-                    // message for this case.
+                    // Filters (or `--all` against an empty repo) removed
+                    // everything. Print the hint so the user gets context
+                    // beyond an empty table.
                     if matches!(format, crate::OutputFormat::Table) {
                         let hint = empty_filter_hint(&filtered, *vulns);
                         Term::stdout().write_line(&hint)?;
@@ -349,6 +353,13 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                     return output_list(&filtered, 0, *page, *limit, format);
                 }
                 let total = filtered.len();
+                if *all {
+                    // No client-side paging: emit every matching bug as a
+                    // single page so JSON consumers and table users alike
+                    // see the full result set.
+                    let effective_limit = u32::try_from(total.max(1)).unwrap_or(u32::MAX);
+                    return output_list(&filtered, total, 1, effective_limit, format);
+                }
                 let page_items = paginate_items(&filtered, *page, *limit);
                 output_list(&page_items, total, *page, *limit, format)
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,62 @@ mod tests {
     }
 
     #[test]
+    fn bugs_list_all_flag_parses() {
+        let cli = Cli::try_parse_from(["detail", "bugs", "list", "owner/repo", "--all"]).unwrap();
+        if let Commands::Bugs {
+            command: commands::bugs::BugCommands::List { all, .. },
+        } = &cli.command
+        {
+            assert!(*all);
+        } else {
+            panic!("expected bugs list command");
+        }
+    }
+
+    #[test]
+    fn bugs_list_all_silences_when_json() {
+        let cli = Cli::try_parse_from([
+            "detail",
+            "bugs",
+            "list",
+            "owner/repo",
+            "--all",
+            "--format",
+            "json",
+        ])
+        .unwrap();
+        assert!(cli.is_silent());
+    }
+
+    #[test]
+    fn bugs_list_all_conflicts_with_page() {
+        let cli = Cli::try_parse_from([
+            "detail",
+            "bugs",
+            "list",
+            "owner/repo",
+            "--all",
+            "--page",
+            "2",
+        ]);
+        assert!(cli.is_err());
+    }
+
+    #[test]
+    fn bugs_list_all_conflicts_with_limit() {
+        let cli = Cli::try_parse_from([
+            "detail",
+            "bugs",
+            "list",
+            "owner/repo",
+            "--all",
+            "--limit",
+            "10",
+        ]);
+        assert!(cli.is_err());
+    }
+
+    #[test]
     fn bugs_list_scan_id_parses() {
         let cli = Cli::try_parse_from([
             "detail",


### PR DESCRIPTION
## Summary
- Triage transcripts kept hitting the 100-per-page cap on `bugs list` and resorting to multi-page shell loops or piggy-backing on `--vulns`/`--introduced-by` (which already auto-paginate internally) just to grab every pending bug.
- This PR exposes the existing `fetch_all_bugs` paginator behind an explicit `--all` flag: it fetches every matching bug, runs the existing filter logic against the full set, and emits the result as a single page.
- `--all` conflicts with `--page` and `--limit` so users get a clear error rather than silently misleading pagination output (e.g. "Page: 1 of 5" while everything is shown).

## Why not raise the cap to 500?
The OpenAPI spec caps `limit` at 100 and the server enforces it, so a higher CLI cap would just produce server-side errors. `--all` is the workable half of the audit's "raise to 500 or add --all" choice and exposes the same paginator the audit pointed at.

## Testing
**Automated, run locally and passing:**
- `cargo test` — full suite green. 4 new clap-parse tests in `src/lib.rs`:
  - `bugs_list_all_flag_parses`
  - `bugs_list_all_silences_when_json` (so JSON output isn't corrupted by update notices)
  - `bugs_list_all_conflicts_with_page`
  - `bugs_list_all_conflicts_with_limit`
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo xtask check` — clean (HELP.md regenerated in 7b557d9)

**Manual end-to-end against live API (repo: usedetail/detail, 305 pending bugs — exceeds the 100/page cap):**
- `bugs list usedetail/detail --status pending --all --format json` → `items=305, total=305, page=1, total_pages=1, unique_ids=305`. All bugs returned in one page, no duplicates across the underlying multi-page server fetches.
- `bugs list usedetail/detail --all --page 2` → `error: the argument '--all' cannot be used with '--page <PAGE>'`
- `bugs list usedetail/detail --all --limit 50` → `error: the argument '--all' cannot be used with '--limit <LIMIT>'`
- `bugs list usedetail/detail --status pending --format json` (regression baseline) → `items=50, total=305, total_pages=7` — single-page server fetch unchanged when `--all` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
