### PR TITLE
fix(api): make BugSource tolerant of unknown backend values

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -175,13 +175,6 @@
         "type": "string"
       },
       "BugSource": {
-        "enum": [
-          "review",
-          "linear",
-          "jira",
-          "github_issue",
-          "bug_fix_check"
-        ],
         "type": "string"
       },
       "CreateRuleInput": {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -343,6 +343,32 @@ mod tests {
         assert!(!keys.contains(&"Linked Issues"));
     }
 
+    /// Regression: backend can ship new `review.source` values (next is
+    /// anyone's guess) faster than we can release a CLI that knows about
+    /// them. Our vendored openapi.json removes the enum from BugSource so
+    /// progenitor generates a `String` and unknown values pass through.
+    #[test]
+    fn bug_with_unknown_review_source_deserializes() {
+        let bug: Result<Bug, _> = serde_json::from_value(serde_json::json!({
+            "id": "bug_unknown_src",
+            "title": "Bug with brand-new review source",
+            "summary": "...",
+            "createdAt": 1,
+            "repoId": "repo_1",
+            "linkedIssues": [],
+            "review": {
+                "state": "resolved",
+                "createdAt": 2,
+                "source": "some_future_integration_we_have_not_shipped_yet"
+            }
+        }));
+        assert!(
+            bug.is_ok(),
+            "Unknown BugSource value broke Bug deserialization: {:?}",
+            bug.err()
+        );
+    }
+
     #[test]
     fn format_linked_issue_linear_with_url() {
         let issue: LinkedIssue = serde_json::from_value(serde_json::json!({

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -88,8 +88,26 @@ fn with_comment(mut value: serde_json::Value) -> serde_json::Value {
     value
 }
 
+/// Apply local-only overrides to the upstream spec.
+///
+/// We strip the `enum` constraint from `BugSource` so progenitor generates a
+/// plain `String` for the field. Released CLIs would otherwise fail to
+/// deserialize any bug review whose `source` matches a backend value the
+/// CLI's vendored spec hasn't seen yet (we got bitten by `github_issue` and
+/// `bug_fix_check` in 0.2.0 → fixed reactively in #255). The CLI never
+/// inspects this field, so the lost type safety costs nothing.
+fn apply_local_overrides(spec: &mut serde_json::Value) {
+    if let Some(schema) = spec
+        .pointer_mut("/components/schemas/BugSource")
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        schema.remove("enum");
+    }
+}
+
 fn generate_openapi() -> Result<(), String> {
-    let upstream = fetch_openapi()?;
+    let mut upstream = fetch_openapi()?;
+    apply_local_overrides(&mut upstream);
     let pretty = serde_json::to_string_pretty(&with_comment(upstream))
         .map_err(|e| format!("Failed to format JSON: {e}"))?;
     std::fs::write(OPENAPI_PATH, format!("{pretty}\n"))
@@ -99,7 +117,8 @@ fn generate_openapi() -> Result<(), String> {
 }
 
 fn check_openapi() -> Result<(), String> {
-    let upstream = fetch_openapi()?;
+    let mut upstream = fetch_openapi()?;
+    apply_local_overrides(&mut upstream);
     let local_bytes = std::fs::read_to_string(OPENAPI_PATH)
         .map_err(|e| format!("Failed to read {OPENAPI_PATH}: {e}"))?;
     let mut local: serde_json::Value = serde_json::from_str(&local_bytes)


### PR DESCRIPTION
## Summary
- 0.2.0 hard-broke `bugs list/show` whenever a review's `source` field carried a backend value our vendored `openapi.json` hadn't seen yet (`github_issue`, `bug_fix_check`). #255 patched the spec reactively — but the *next* new value will break every released CLI in the wild the same way.
- Drop the `enum` constraint from `BugSource` in the vendored `openapi.json` so progenitor generates a plain `String` for the field; unknown values now deserialize fine. The CLI never inspects this field, so the lost type safety costs nothing.
- Teach `cargo xtask {generate,check}-openapi` to apply the same override after fetching upstream so future regenerations stay tolerant and CI's `check-openapi` stays green.
- Adds a regression test in `src/api/types.rs` that deserializes a Bug with an invented `review.source`.

## Test plan
- [x] `cargo test --lib` — new `bug_with_unknown_review_source_deserializes` test passes
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo build` — progenitor regenerates `BugReview` with `source: Option<String>`
- [ ] `cargo xtask check-openapi` against the live upstream (needs network)
- [ ] `cargo xtask generate-openapi` then `git diff openapi.json` shows no enum reintroduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)