### PR TITLE
feat(bugs): show file path, security flag, and introducing PR in list cards

### DIFF
--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -49,6 +49,21 @@ pub const fn rule_status_label(s: &RuleStatus) -> &'static str {
     }
 }
 
+/// Format blame/attribution info for display, e.g. "PR #42 (abc1234) on 2024-12-23 by alice".
+pub fn format_introduced_in(intro: &IntroducedIn) -> String {
+    let commit = intro.sha.get(..7).unwrap_or(&intro.sha);
+    let ref_label = intro
+        .pr_number
+        .map_or_else(|| commit.to_string(), |pr| format!("PR #{pr} ({commit})"));
+    let date_part = format!(" on {}", intro.date);
+    let author_part = intro
+        .author
+        .as_deref()
+        .map(|a| format!(" by {a}"))
+        .unwrap_or_default();
+    format!("{ref_label}{date_part}{author_part}")
+}
+
 /// Format a linked issue for display. Includes the URL for the detail/show view.
 pub fn format_linked_issue(issue: &LinkedIssue) -> String {
     let tracker = issue.tracker.to_string();
@@ -105,6 +120,19 @@ impl Formattable for Bug {
             ("Bug ID", self.id.to_string()),
             ("Created", format_date(self.created_at)),
         ];
+        // Each remaining field is conditional so non-applicable bugs don't
+        // get a forest of "-" rows. Triage threads regularly need file path
+        // and introducing PR — pulling them straight from `--format json`
+        // costs no extra round-trip vs. the previous N+1 `bugs show` loop.
+        if let Some(path) = self.file_path.as_deref() {
+            pairs.push(("File", path.to_string()));
+        }
+        if self.is_security_vulnerability == Some(true) {
+            pairs.push(("Security", "Yes".to_string()));
+        }
+        if let Some(intro) = &self.introduced_in {
+            pairs.push(("Introduced", format_introduced_in(intro)));
+        }
         if !self.linked_issues.is_empty() {
             let formatted = self
                 .linked_issues
@@ -280,39 +308,10 @@ mod tests {
         assert_eq!(pairs[1].1, format_date(1_736_899_200_000));
     }
 
-    #[test]
-    fn bug_card_omits_security_when_true() {
-        let bug: Bug = serde_json::from_value(serde_json::json!({
-            "id": "bug_sec1",
-            "title": "XSS vulnerability",
-            "summary": "...",
-            "createdAt": 1_736_899_200_000_i64,
-            "repoId": "repo_xyz",
-            "isSecurityVulnerability": true,
-            "linkedIssues": []
-        }))
-        .expect("valid Bug JSON");
-        let (_, pairs) = bug.to_card();
-        let keys: Vec<&str> = pairs.iter().map(|(k, _)| *k).collect();
-        assert_eq!(keys, vec!["Bug ID", "Created"]);
-    }
-
-    #[test]
-    fn bug_card_hides_security_when_false() {
-        let bug: Bug = serde_json::from_value(serde_json::json!({
-            "id": "bug_nosec",
-            "title": "Typo in docs",
-            "summary": "...",
-            "createdAt": 1_736_899_200_000_i64,
-            "repoId": "repo_xyz",
-            "isSecurityVulnerability": false,
-            "linkedIssues": []
-        }))
-        .expect("valid Bug JSON");
-        let (_, pairs) = bug.to_card();
-        let keys: Vec<&str> = pairs.iter().map(|(k, _)| *k).collect();
-        assert_eq!(keys, vec!["Bug ID", "Created"]);
-    }
+    // The old `bug_card_omits_security_when_true` and `_hides_security_when_false`
+    // tests asserted that `Security` was never emitted; that's now superseded
+    // by `bug_card_includes_security_only_when_true` below, which exercises
+    // all three states (None / false / true).
 
     #[test]
     fn bug_card_shows_linked_issues_when_present() {
@@ -341,6 +340,158 @@ mod tests {
         let (_, pairs) = sample_bug().to_card();
         let keys: Vec<&str> = pairs.iter().map(|(k, _)| *k).collect();
         assert!(!keys.contains(&"Linked Issues"));
+    }
+
+    // ── richer Bug card: File / Security / Introduced ────────────────
+
+    #[test]
+    fn bug_card_omits_file_when_absent() {
+        let (_, pairs) = sample_bug().to_card();
+        assert!(!pairs.iter().any(|(k, _)| *k == "File"));
+    }
+
+    #[test]
+    fn bug_card_includes_file_when_present() {
+        let bug: Bug = serde_json::from_value(serde_json::json!({
+            "id": "bug_filed", "title": "...", "summary": "...",
+            "createdAt": 1, "repoId": "repo_1", "linkedIssues": [],
+            "filePath": "src/handlers/login.rs"
+        }))
+        .expect("valid Bug JSON");
+        let (_, pairs) = bug.to_card();
+        let value = pairs.iter().find(|(k, _)| *k == "File").map(|(_, v)| v);
+        assert_eq!(value, Some(&"src/handlers/login.rs".to_string()));
+    }
+
+    #[test]
+    fn bug_card_includes_security_only_when_true() {
+        // None and false should *not* emit the Security row — keeps the
+        // table view quiet for non-vulns.
+        let none_bug = sample_bug();
+        assert!(!none_bug.to_card().1.iter().any(|(k, _)| *k == "Security"));
+
+        let false_bug: Bug = serde_json::from_value(serde_json::json!({
+            "id": "bug_safe", "title": "...", "summary": "...",
+            "createdAt": 1, "repoId": "repo_1", "linkedIssues": [],
+            "isSecurityVulnerability": false
+        }))
+        .expect("valid Bug JSON");
+        assert!(!false_bug.to_card().1.iter().any(|(k, _)| *k == "Security"));
+
+        let true_bug: Bug = serde_json::from_value(serde_json::json!({
+            "id": "bug_vuln", "title": "...", "summary": "...",
+            "createdAt": 1, "repoId": "repo_1", "linkedIssues": [],
+            "isSecurityVulnerability": true
+        }))
+        .expect("valid Bug JSON");
+        let (_, pairs) = true_bug.to_card();
+        let v = pairs.iter().find(|(k, _)| *k == "Security").map(|(_, v)| v);
+        assert_eq!(v, Some(&"Yes".to_string()));
+    }
+
+    #[test]
+    fn bug_card_includes_introduced_when_present() {
+        let bug: Bug = serde_json::from_value(serde_json::json!({
+            "id": "bug_blamed", "title": "...", "summary": "...",
+            "createdAt": 1, "repoId": "repo_1", "linkedIssues": [],
+            "introducedIn": { "sha": "abc1234def", "date": "2024-12-23",
+                              "prNumber": 42, "author": "alice" }
+        }))
+        .expect("valid Bug JSON");
+        let (_, pairs) = bug.to_card();
+        let v = pairs
+            .iter()
+            .find(|(k, _)| *k == "Introduced")
+            .map(|(_, v)| v);
+        assert_eq!(
+            v,
+            Some(&"PR #42 (abc1234) on 2024-12-23 by alice".to_string())
+        );
+    }
+
+    // ── format_introduced_in ─────────────────────────────────────────
+
+    #[test]
+    fn format_introduced_in_full_sha_with_pr_and_author() {
+        let intro = IntroducedIn {
+            sha: "abc1234def5678".to_string(),
+            date: "2024-12-23".to_string(),
+            pr_number: Some(42),
+            author: Some("alice".to_string()),
+        };
+        assert_eq!(
+            format_introduced_in(&intro),
+            "PR #42 (abc1234) on 2024-12-23 by alice"
+        );
+    }
+
+    #[test]
+    fn format_introduced_in_no_pr_number() {
+        let intro = IntroducedIn {
+            sha: "abc1234def5678".to_string(),
+            date: "2024-12-23".to_string(),
+            pr_number: None,
+            author: Some("bob".to_string()),
+        };
+        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-12-23 by bob");
+    }
+
+    #[test]
+    fn format_introduced_in_no_author() {
+        let intro = IntroducedIn {
+            sha: "abc1234def5678".to_string(),
+            date: "2024-12-23".to_string(),
+            pr_number: Some(99),
+            author: None,
+        };
+        assert_eq!(
+            format_introduced_in(&intro),
+            "PR #99 (abc1234) on 2024-12-23"
+        );
+    }
+
+    #[test]
+    fn format_introduced_in_no_pr_no_author() {
+        let intro = IntroducedIn {
+            sha: "abc1234def5678".to_string(),
+            date: "2024-12-23".to_string(),
+            pr_number: None,
+            author: None,
+        };
+        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-12-23");
+    }
+
+    #[test]
+    fn format_introduced_in_short_sha() {
+        let intro = IntroducedIn {
+            sha: "abc".to_string(),
+            date: "2024-01-01".to_string(),
+            pr_number: None,
+            author: None,
+        };
+        assert_eq!(format_introduced_in(&intro), "abc on 2024-01-01");
+    }
+
+    #[test]
+    fn format_introduced_in_exactly_7_char_sha() {
+        let intro = IntroducedIn {
+            sha: "abc1234".to_string(),
+            date: "2024-01-01".to_string(),
+            pr_number: None,
+            author: None,
+        };
+        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-01-01");
+    }
+
+    #[test]
+    fn format_introduced_in_empty_sha() {
+        let intro = IntroducedIn {
+            sha: String::new(),
+            date: "2024-01-01".to_string(),
+            pr_number: None,
+            author: None,
+        };
+        assert_eq!(format_introduced_in(&intro), " on 2024-01-01");
     }
 
     #[test]

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -7,8 +7,8 @@ use dialoguer::{Input, Select};
 
 use crate::api::client::ApiClient;
 use crate::api::types::{
-    dismissal_reason_label, format_linked_issue, review_state_label, Bug, BugDismissalReason,
-    BugId, BugReviewState, IntroducedIn, ListPublicBugsWorkflowRequestId, RepoId,
+    dismissal_reason_label, format_introduced_in, format_linked_issue, review_state_label, Bug,
+    BugDismissalReason, BugId, BugReviewState, ListPublicBugsWorkflowRequestId, RepoId,
 };
 use crate::output::{output_list, SectionRenderer};
 use crate::utils::datetime::format_datetime;
@@ -83,21 +83,6 @@ fn paginate_items<T: Clone>(items: &[T], page: u32, limit: u32) -> Vec<T> {
         .take(usize::try_from(limit).unwrap_or(0))
         .cloned()
         .collect()
-}
-
-/// Format blame/attribution info for display, e.g. "PR #42 (abc1234) on 2024-12-23 by alice".
-fn format_introduced_in(intro: &IntroducedIn) -> String {
-    let commit = intro.sha.get(..7).unwrap_or(&intro.sha);
-    let ref_label = intro
-        .pr_number
-        .map_or_else(|| commit.to_string(), |pr| format!("PR #{pr} ({commit})"));
-    let date_part = format!(" on {}", intro.date);
-    let author_part = intro
-        .author
-        .as_deref()
-        .map(|a| format!(" by {a}"))
-        .unwrap_or_default();
-    format!("{ref_label}{date_part}{author_part}")
 }
 
 #[derive(Subcommand)]
@@ -796,90 +781,6 @@ mod tests {
         assert!(page.is_empty());
     }
 
-    // ── format_introduced_in ─────────────────────────────────────────
-
-    #[test]
-    fn format_introduced_in_full_sha_with_pr_and_author() {
-        let intro = IntroducedIn {
-            sha: "abc1234def5678".to_string(),
-            date: "2024-12-23".to_string(),
-            pr_number: Some(42),
-            author: Some("alice".to_string()),
-        };
-        assert_eq!(
-            format_introduced_in(&intro),
-            "PR #42 (abc1234) on 2024-12-23 by alice"
-        );
-    }
-
-    #[test]
-    fn format_introduced_in_no_pr_number() {
-        let intro = IntroducedIn {
-            sha: "abc1234def5678".to_string(),
-            date: "2024-12-23".to_string(),
-            pr_number: None,
-            author: Some("bob".to_string()),
-        };
-        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-12-23 by bob");
-    }
-
-    #[test]
-    fn format_introduced_in_no_author() {
-        let intro = IntroducedIn {
-            sha: "abc1234def5678".to_string(),
-            date: "2024-12-23".to_string(),
-            pr_number: Some(99),
-            author: None,
-        };
-        assert_eq!(
-            format_introduced_in(&intro),
-            "PR #99 (abc1234) on 2024-12-23"
-        );
-    }
-
-    #[test]
-    fn format_introduced_in_no_pr_no_author() {
-        let intro = IntroducedIn {
-            sha: "abc1234def5678".to_string(),
-            date: "2024-12-23".to_string(),
-            pr_number: None,
-            author: None,
-        };
-        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-12-23");
-    }
-
-    #[test]
-    fn format_introduced_in_short_sha() {
-        // SHA shorter than 7 chars should use the full SHA
-        let intro = IntroducedIn {
-            sha: "abc".to_string(),
-            date: "2024-01-01".to_string(),
-            pr_number: None,
-            author: None,
-        };
-        assert_eq!(format_introduced_in(&intro), "abc on 2024-01-01");
-    }
-
-    #[test]
-    fn format_introduced_in_exactly_7_char_sha() {
-        let intro = IntroducedIn {
-            sha: "abc1234".to_string(),
-            date: "2024-01-01".to_string(),
-            pr_number: None,
-            author: None,
-        };
-        assert_eq!(format_introduced_in(&intro), "abc1234 on 2024-01-01");
-    }
-
-    #[test]
-    fn format_introduced_in_empty_sha() {
-        let intro = IntroducedIn {
-            sha: "".to_string(),
-            date: "2024-01-01".to_string(),
-            pr_number: None,
-            author: None,
-        };
-        // Empty SHA hits unwrap_or, returns empty string
-        assert_eq!(format_introduced_in(&intro), " on 2024-01-01");
-    }
+    // `format_introduced_in` moved to `crate::api::types`; tests now live
+    // alongside the function in `src/api/types.rs`.
 }


### PR DESCRIPTION
## Summary
Triage threads ran N+1 calls — 1 `bugs list` + N `bugs show` — just to read fields already present in the list response. The table card only printed `Bug ID`, `Created`, and (sometimes) `Linked Issues`, so anyone wanting `filePath` or `introducedIn.prNumber` had to round-trip per bug.

Add three conditional rows to `Formattable for Bug` so `bugs list` shows the most useful triage signal inline:
- **File** — `bug.file_path` when present
- **Security** — "Yes" when `isSecurityVulnerability` is `true` (suppressed for `false`/`null` so non-vulns stay quiet in long lists)
- **Introduced** — `bug.introduced_in` formatted via the existing `format_introduced_in` helper

Each row is conditional, matching how `Linked Issues` already works — no forest of "-" rows for non-applicable bugs. JSON output is unchanged: this only affects the human/table view.

`format_introduced_in` moved from `commands/bugs.rs` to `api/types.rs` so the impl and its tests sit next to the card that uses it. `bugs show` continues to use the same function — no duplication.

The audit suggested a `--wide`/`-l` flag instead of unconditional surfacing; the conditional approach achieves the same goal (only show rows that have data) without forcing users to remember a flag.

## Why no `severity` row?
The audit mentioned `severity` alongside `filePath`/`prNumber`, but the openapi.json `Bug` schema doesn't expose a `severity` field today. `Security: Yes` is the closest signal we have; happy to add `severity` later if the backend ships it.

## Testing
**Automated, run locally and passing:**
- `cargo test` — full suite green. Tests added/moved in `src/api/types.rs`:
  - `bug_card_omits_file_when_absent`, `bug_card_includes_file_when_present`
  - `bug_card_includes_security_only_when_true` — covers all three states (None / false / true), supersedes the dropped `bug_card_omits_security_when_true` and `_hides_security_when_false` (which encoded the old "always omit" rule)
  - `bug_card_includes_introduced_when_present`
  - 7 `format_introduced_in_*` tests moved from `commands/bugs.rs` to live next to the function
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo xtask check` — clean (no flag changes, so HELP.md stays the same)

**Manual end-to-end against live API (`usedetail/detail`):**
- `bugs list usedetail/detail --status pending --limit 3` — table now renders File and Introduced inline:
  ```
  1. Scan setup: Recurring scans remain disabled after installing GitHub app in another tab
      Bug ID         bug_dc5d7ce0-…
      Created        2026-05-05
      File           apps/frontend/src/app/(authed)/[org_id]/(sidebar)/scans/new/_components/ReviewScanStep.tsx
      Introduced     PR #9929 (c00f3d0) on 2026-03-30T18:02:24Z by gauntface
  ```
- `bugs list usedetail/detail --vulns --limit 1` — `Security: Yes` only appears for security vulns:
  ```
  1. K8s agent jobs receive Pulumi/Vercel infrastructure secrets via ENV_KEYS
      Bug ID         bug_3270a5b1-…
      Created        2026-04-24
      File           packages/env/src/env.ts
      Security       Yes
      Introduced     PR #10788 (643ea19) on 2026-04-24T09:30:36Z by sachiniyer
      Linked Issues  github: #10807, jira: MBA-251, linear: DET-1205, slack
  ```
- Verified `Linked Issues` still appears in its previous position when present.
- `--format json` output byte-equivalent to baseline (the JSON serializer doesn't go through `to_card`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
