### PR TITLE
feat(bugs): add --format json to bugs show and bugs close

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -159,11 +159,20 @@ List bugs for a given repository
 
 Show the report for a bug
 
-**Usage:** `detail bugs show <BUG_ID>`
+**Usage:** `detail bugs show [OPTIONS] <BUG_ID>`
 
 ###### **Arguments:**
 
 * `<BUG_ID>` — Bug ID
+
+###### **Options:**
+
+* `--format <FORMAT>` — Output format
+
+  Default value: `table`
+
+  Possible values: `table`, `json`
+
 
 
 
@@ -188,6 +197,12 @@ Close a bug as resolved or dismissed
   Possible values: `not-a-bug`, `wont-fix`, `duplicate`, `other`
 
 * `--notes <NOTES>` — Additional notes
+* `--format <FORMAT>` — Output format
+
+  Default value: `table`
+
+  Possible values: `table`, `json`
+
 
 
 

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -130,6 +130,10 @@ pub enum BugCommands {
     Show {
         /// Bug ID
         bug_id: String,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "table")]
+        format: crate::OutputFormat,
     },
 
     /// Close a bug as resolved or dismissed
@@ -148,6 +152,10 @@ pub enum BugCommands {
         /// Additional notes
         #[arg(long)]
         notes: Option<String>,
+
+        /// Output format
+        #[arg(long, value_enum, default_value = "table")]
+        format: crate::OutputFormat,
     },
 
     /// Reopen a previously resolved or dismissed bug — flips it back to
@@ -257,6 +265,42 @@ fn validate_close_flags(
     };
 
     Ok((state, dismissal_reason, notes))
+}
+
+/// Render a single bug as the human-readable `bugs show` view.
+fn render_bug_show(bug: &Bug) -> Result<()> {
+    let mut pairs: Vec<(&str, String)> = vec![
+        ("ID", bug.id.to_string()),
+        ("Title", bug.title.clone()),
+        ("File", bug.file_path.as_deref().unwrap_or("-").to_string()),
+        ("Created", format_datetime(bug.created_at)),
+        (
+            "Security",
+            bug.is_security_vulnerability
+                .map_or("-", |v| if v { "Yes" } else { "No" })
+                .to_string(),
+        ),
+    ];
+    if let Some(intro) = &bug.introduced_in {
+        pairs.push(("Introduced", format_introduced_in(intro)));
+    }
+    if let Some(review) = &bug.review {
+        pairs.push(("Close", review_state_label(&review.state).to_string()));
+        pairs.push(("Close Date", format_datetime(review.created_at)));
+        if let Some(reason) = &review.dismissal_reason {
+            pairs.push(("Dismissal", dismissal_reason_label(reason).to_string()));
+        }
+        if let Some(notes) = &review.notes {
+            pairs.push(("Notes", notes.clone()));
+        }
+    }
+    for issue in &bug.linked_issues {
+        pairs.push(("Issue", format_linked_issue(issue)));
+    }
+    SectionRenderer::new()
+        .key_value("", &pairs)
+        .markdown("", &bug.summary)
+        .print()
 }
 
 /// Page size used when scanning all bugs for client-side vulnerability filtering.
@@ -372,7 +416,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
             }
         }
 
-        BugCommands::Show { bug_id } => {
+        BugCommands::Show { bug_id, format } => {
             let bug_id: BugId = bug_id
                 .as_str()
                 .try_into()
@@ -382,38 +426,11 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                 .await
                 .context("Failed to fetch bug details")?;
 
-            let mut pairs: Vec<(&str, String)> = vec![
-                ("ID", bug.id.to_string()),
-                ("Title", bug.title.clone()),
-                ("File", bug.file_path.as_deref().unwrap_or("-").to_string()),
-                ("Created", format_datetime(bug.created_at)),
-                (
-                    "Security",
-                    bug.is_security_vulnerability
-                        .map_or("-", |v| if v { "Yes" } else { "No" })
-                        .to_string(),
-                ),
-            ];
-            if let Some(intro) = &bug.introduced_in {
-                pairs.push(("Introduced", format_introduced_in(intro)));
+            if matches!(format, crate::OutputFormat::Json) {
+                Term::stdout().write_line(&serde_json::to_string_pretty(&bug)?)?;
+                return Ok(());
             }
-            if let Some(review) = &bug.review {
-                pairs.push(("Close", review_state_label(&review.state).to_string()));
-                pairs.push(("Close Date", format_datetime(review.created_at)));
-                if let Some(reason) = &review.dismissal_reason {
-                    pairs.push(("Dismissal", dismissal_reason_label(reason).to_string()));
-                }
-                if let Some(notes) = &review.notes {
-                    pairs.push(("Notes", notes.clone()));
-                }
-            }
-            for issue in &bug.linked_issues {
-                pairs.push(("Issue", format_linked_issue(issue)));
-            }
-            SectionRenderer::new()
-                .key_value("", &pairs)
-                .markdown("", &bug.summary)
-                .print()
+            render_bug_show(&bug)
         }
 
         BugCommands::Close {
@@ -421,6 +438,7 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
             state,
             dismissal_reason,
             notes,
+            format,
         } => {
             let bug_id: BugId = bug_id
                 .as_str()
@@ -452,10 +470,17 @@ pub async fn handle(command: &BugCommands, cli: &crate::Cli) -> Result<()> {
                 None => None,
             };
 
-            client
+            let review = client
                 .update_bug_close(&bug_id, state, dismissal_reason, notes.as_deref())
                 .await
                 .context("Failed to close bug")?;
+
+            if matches!(format, crate::OutputFormat::Json) {
+                // Emit only the BugReview JSON — the human-friendly success
+                // banner would corrupt the structured output.
+                Term::stdout().write_line(&serde_json::to_string_pretty(&review)?)?;
+                return Ok(());
+            }
 
             Term::stdout()
                 .write_line(&format!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,10 @@ impl Cli {
     const fn is_silent(&self) -> bool {
         match &self.command {
             Commands::Bugs { command } => match command {
-                commands::bugs::BugCommands::List { format, .. } => Self::is_json(format),
-                commands::bugs::BugCommands::Show { .. }
-                | commands::bugs::BugCommands::Close { .. }
-                | commands::bugs::BugCommands::Reopen { .. } => false,
+                commands::bugs::BugCommands::List { format, .. }
+                | commands::bugs::BugCommands::Show { format, .. }
+                | commands::bugs::BugCommands::Close { format, .. } => Self::is_json(format),
+                commands::bugs::BugCommands::Reopen { .. } => false,
             },
             Commands::Repos { command } => match command {
                 commands::repos::RepoCommands::List { format, .. } => Self::is_json(format),
@@ -265,6 +265,13 @@ mod tests {
     }
 
     #[test]
+    fn silent_when_bugs_show_json() {
+        let cli =
+            Cli::try_parse_from(["detail", "bugs", "show", "bug_123", "--format", "json"]).unwrap();
+        assert!(cli.is_silent());
+    }
+
+    #[test]
     fn not_silent_for_bugs_close() {
         let cli =
             Cli::try_parse_from(["detail", "bugs", "close", "bug_123", "--state", "resolved"])
@@ -298,8 +305,18 @@ mod tests {
 
     #[test]
     fn not_silent_for_bugs_reopen() {
+        // Reopen has no JSON output to corrupt, so update notices stay on.
         let cli = Cli::try_parse_from(["detail", "bugs", "reopen", "bug_123"]).unwrap();
         assert!(!cli.is_silent());
+    }
+
+    #[test]
+    fn silent_when_bugs_close_json() {
+        let cli = Cli::try_parse_from([
+            "detail", "bugs", "close", "bug_123", "--state", "resolved", "--format", "json",
+        ])
+        .unwrap();
+        assert!(cli.is_silent());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Triage agents repeatedly grep stdout for fields that are already in the JSON payload — bug metadata (file path, security flag, blame, summary) for `show`, and the resulting `BugReview` for `close`. Only `bugs list` accepted `--format json`; `show` and `close` forced text-parsing.

Add `--format <table|json>` (default `table`) to both subcommands:
- `bugs show <id> --format json` — emits the full `Bug` payload (id, title, summary, filePath, introducedIn, review, linkedIssues, …)
- `bugs close <id> --state <s> --format json` — emits the resulting `BugReview`, suppressing the human-friendly "✓ Bug closed as: …" banner so stdout is pure JSON

`is_silent` extended to suppress auto-update notices on the new JSON paths, matching how `bugs list --format json` already works.

The table-view body of `Show` is unchanged; extracted into a `render_bug_show` helper so the handler match arm just dispatches on format.

## Testing
**Automated, run locally and passing:**
- `cargo test` — full suite green. New clap-parse tests in `src/lib.rs`:
  - `silent_when_bugs_show_json` — `bugs show … --format json` triggers the silent-output path
  - `silent_when_bugs_close_json` — same for close
  - Existing `not_silent_for_bugs_show` / `not_silent_for_bugs_close` still pass (default format is `table`)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo xtask check` — clean (HELP.md regenerated for the two new flags)

**Manual end-to-end against live API:**
- `bugs show bug_5d237de8-… --format json` → valid JSON, all expected fields present:
  ```
  keys: ['createdAt', 'filePath', 'id', 'introducedIn', 'isSecurityVulnerability',
         'linkedIssues', 'repoId', 'summary', 'title']
  ```
- `bugs show bug_5d237de8-…` (default) → unchanged: ID/Title/File/Created/Security/Introduced/Issue rows + markdown summary
- `bugs close bug_e79362bd-… --state dismissed --dismissal-reason not-a-bug --format json` (idempotent re-close on an already-dismissed bug) → emits the `BugReview` JSON only, no `✓ Bug closed as:` banner. `head -1` of stdout is just `{`.
- `bugs show bug_does_not_exist --format json` → `Error: Failed to fetch bug details` (still propagates errors via stderr; stdout stays empty)

**⚠️ Pre-existing bug found while testing (not part of this PR, flagged for follow-up):**
`bugs close` without `--notes` overwrites any existing `review.notes` with `null` — the API client sends `notes: None` which the backend treats as "set to null" rather than "leave unchanged". Caught when re-closing an already-dismissed bug for this PR's smoke test; the original notes were restored manually. Not introduced by this PR but tagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
