### PR TITLE
feat(output): add --format json-array for unwrapped list output

### DIFF
--- a/docs/HELP.md
+++ b/docs/HELP.md
@@ -147,7 +147,13 @@ List bugs for a given repository
 
   Default value: `table`
 
-  Possible values: `table`, `json`
+  Possible values:
+  - `table`:
+    Human-readable table view (default)
+  - `json`:
+    Wrapped JSON with `{items, total, page, total_pages}` envelope — useful when you need pagination metadata
+  - `json-array`:
+    Top-level JSON array of items, no envelope. Drop-in for `python -c 'json.load(...)'` consumers and `jq '.[]'`
 
 
 
@@ -272,7 +278,13 @@ List rule creation requests for a repository
 
   Default value: `table`
 
-  Possible values: `table`, `json`
+  Possible values:
+  - `table`:
+    Human-readable table view (default)
+  - `json`:
+    Wrapped JSON with `{items, total, page, total_pages}` envelope — useful when you need pagination metadata
+  - `json-array`:
+    Top-level JSON array of items, no envelope. Drop-in for `python -c 'json.load(...)'` consumers and `jq '.[]'`
 
 
 
@@ -305,7 +317,13 @@ List completed rules for a repository
 
   Default value: `table`
 
-  Possible values: `table`, `json`
+  Possible values:
+  - `table`:
+    Human-readable table view (default)
+  - `json`:
+    Wrapped JSON with `{items, total, page, total_pages}` envelope — useful when you need pagination metadata
+  - `json-array`:
+    Top-level JSON array of items, no envelope. Drop-in for `python -c 'json.load(...)'` consumers and `jq '.[]'`
 
 
 
@@ -376,7 +394,13 @@ List all repositories you have access to
 
   Default value: `table`
 
-  Possible values: `table`, `json`
+  Possible values:
+  - `table`:
+    Human-readable table view (default)
+  - `json`:
+    Wrapped JSON with `{items, total, page, total_pages}` envelope — useful when you need pagination metadata
+  - `json-array`:
+    Top-level JSON array of items, no envelope. Drop-in for `python -c 'json.load(...)'` consumers and `jq '.[]'`
 
 
 
@@ -415,7 +439,13 @@ List recent scans for a repository
 
   Default value: `table`
 
-  Possible values: `table`, `json`
+  Possible values:
+  - `table`:
+    Human-readable table view (default)
+  - `json`:
+    Wrapped JSON with `{items, total, page, total_pages}` envelope — useful when you need pagination metadata
+  - `json-array`:
+    Top-level JSON array of items, no envelope. Drop-in for `python -c 'json.load(...)'` consumers and `jq '.[]'`
 
 
 

--- a/src/commands/repos.rs
+++ b/src/commands/repos.rs
@@ -69,7 +69,7 @@ pub async fn handle(command: &RepoCommands, cli: &crate::Cli) -> Result<()> {
                     term.write_line(&format!("Page: {page} of {total_pages}"))?;
                     Ok(())
                 }
-                crate::OutputFormat::Json => output_list(
+                crate::OutputFormat::Json | crate::OutputFormat::JsonArray => output_list(
                     &repos.repos,
                     usize::try_from(repos.total.max(0)).unwrap_or(0),
                     *page,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ impl Cli {
     }
 
     const fn is_json(format: &OutputFormat) -> bool {
-        matches!(format, OutputFormat::Json)
+        format.is_machine_readable()
     }
 
     /// Returns true when machine-readable output is requested (e.g. `--format json`),
@@ -118,8 +118,21 @@ impl Cli {
 
 #[derive(Clone, clap::ValueEnum)]
 pub enum OutputFormat {
+    /// Human-readable table view (default).
     Table,
+    /// Wrapped JSON with `{items, total, page, total_pages}` envelope —
+    /// useful when you need pagination metadata.
     Json,
+    /// Top-level JSON array of items, no envelope. Drop-in for
+    /// `python -c 'json.load(...)'` consumers and `jq '.[]'`.
+    JsonArray,
+}
+
+impl OutputFormat {
+    /// Returns true for any machine-readable variant.
+    const fn is_machine_readable(&self) -> bool {
+        matches!(self, Self::Json | Self::JsonArray)
+    }
 }
 
 #[derive(Subcommand)]
@@ -183,6 +196,27 @@ mod tests {
         let cli = Cli::try_parse_from(["detail", "bugs", "list", "owner/repo", "--format", "json"])
             .unwrap();
         assert!(cli.is_silent());
+    }
+
+    #[test]
+    fn silent_when_bugs_list_json_array() {
+        let cli = Cli::try_parse_from([
+            "detail",
+            "bugs",
+            "list",
+            "owner/repo",
+            "--format",
+            "json-array",
+        ])
+        .unwrap();
+        assert!(cli.is_silent());
+    }
+
+    #[test]
+    fn json_array_is_machine_readable() {
+        assert!(OutputFormat::JsonArray.is_machine_readable());
+        assert!(OutputFormat::Json.is_machine_readable());
+        assert!(!OutputFormat::Table.is_machine_readable());
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -138,6 +138,13 @@ pub fn output_list<T: Formattable + Serialize>(
             });
             Term::stdout().write_line(&serde_json::to_string_pretty(&response)?)?;
         }
+        crate::OutputFormat::JsonArray => {
+            // No envelope: the items are the entire payload. Drops the
+            // pagination metadata — callers who need it should use `json`.
+            // This is the shape `python -c 'bugs = json.load(...)'` and
+            // `jq '.[]'` consumers expect by default.
+            Term::stdout().write_line(&serde_json::to_string_pretty(items)?)?;
+        }
         crate::OutputFormat::Table => {
             let term = Term::stdout();
             let max_key = items


### PR DESCRIPTION
## Summary
Triage agents kept tripping on `--format json`'s envelope shape:

```
$ detail bugs list ... --format json | python -c 'bugs = json.load(...); print(len(bugs))'
AttributeError: 'str' object has no attribute 'get'
```

The actual payload is `{"items": [...], "total": N, "page": 1, "total_pages": M}` — useful for paginated tooling, surprising for the dominant `python -c` / `jq '.[]'` use case.

Add a third `OutputFormat` variant — `json-array` — that emits the top-level array of items directly, dropping the envelope. Available everywhere `--format json` is:
- `bugs list`
- `scans list`
- `repos list`
- `rules list`
- `rules requests list`

The existing `json` shape is preserved verbatim — this is **purely additive, not a breaking change**.

The variant doc-comments now also explain when to reach for each:
- `json` — envelope with pagination metadata (use when you need `total`/`page`/`total_pages`)
- `json-array` — drop-in for `python -c 'json.load(...)'` / `jq '.[]'` consumers

`is_silent` is driven through `OutputFormat::is_machine_readable`, so update notices are suppressed for both JSON variants.

## Why not switch defaults?
The audit suggested making top-level array the default and putting the envelope behind a flag. That's a breaking change for anyone scripting against `--format json` today. Left as a follow-up — additive `json-array` is the safer half of the audit.

## Testing
**Automated, run locally and passing:**
- `cargo test` — full suite green. New tests in `src/lib.rs`:
  - `silent_when_bugs_list_json_array` — auto-update notices suppressed
  - `json_array_is_machine_readable` — `OutputFormat::is_machine_readable` covers both JSON variants
- `cargo clippy -- -D warnings` — clean (caught a non-exhaustive `match` in `repos.rs` that I fixed by extending the existing `Json` arm to also handle `JsonArray`)
- `cargo fmt --check` — clean
- `cargo xtask check` — clean (HELP.md regenerated for the new variant on 5 list commands)

**Manual end-to-end against live API (`usedetail/cli`):**
- `bugs list usedetail/cli --format json --limit 2` → `dict` with keys `['items', 'page', 'total', 'total_pages']`, `items` length 2 (envelope unchanged)
- `bugs list usedetail/cli --format json-array --limit 2` → `list`, length 2, first item `{ "id": "bug_5d237de8-…", … }`
- The audit's evidence pattern `… | python -c 'bugs = json.load(...); print(len(bugs))'` now succeeds: `got 2 bugs`
- `scans list usedetail/cli --format json-array --limit 1` → `list`, length 1
- `repos list --format json-array --limit 1` → `list`, length 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
