### PR TITLE
fix(skills): drop $ARGUMENTS from detail-bugs and detail-create-rules

### DIFF
--- a/.claude/skills/detail-bugs/SKILL.md
+++ b/.claude/skills/detail-bugs/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: detail-bugs
 description: Fetch Detail bugs for a repository. List pending bugs, show details for each, fix the bugs, and mark them as resolved or dismissed.
-argument-hint: <owner/repo>
 ---
 
 # Fetch Detail Bugs
@@ -10,11 +9,7 @@ Get bugs from Detail for a repository and help the user triage them.
 
 ## Determining the Repository
 
-If `$ARGUMENTS` is not empty, use it as the repository (`owner/repo`) for all `detail bugs` commands.
-
-Otherwise, the Detail CLI will infer the repository from the git remote. Use the CLI with no repository specified.
-
-If commands fail to infer the repository, ask the user to provide the repository and use it for the `detail bugs` commands.
+The Detail CLI infers the repository from the git remote; if the user specifies a different repo, pass it explicitly to the CLI commands.
 
 ## Prerequisites
 
@@ -30,14 +25,14 @@ The user must be authenticated. Assume that the user is authed and run commands 
 To scope bugs to a particular scan, first get the scan's workflow request ID:
 
 ```bash
-detail scans list $ARGUMENTS
+detail scans list
 ```
 
 The output includes a `Workflow ID` column (values like `wr_...`). Then pass
 that ID to `bugs list`:
 
 ```bash
-detail bugs list $ARGUMENTS --scan-id <workflow_request_id>
+detail bugs list --scan-id <workflow_request_id>
 ```
 
 This returns only bugs found in that scan, still filtered by `--status`
@@ -46,7 +41,7 @@ closed bugs for the scan.
 
 ## Step 1: List pending bugs
 
-Run `detail bugs list $ARGUMENTS` to fetch all pending bugs.
+Run `detail bugs list` to fetch all pending bugs.
 
 Present the list to the user and ask which bug they want to look at first, or
 offer to go through them in order.

--- a/.claude/skills/detail-create-rules/SKILL.md
+++ b/.claude/skills/detail-create-rules/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: detail-create-rules
 description: Interactively create a new Detail rule for a repository — gather context, submit the creation request, wait for completion, review the results, and pull them locally. Use when asked to "create a rule", "add a rule", "propose rules", "create/propose a Detail rule", or similar.
-argument-hint: <owner/repo>
 ---
 
 # Create a Detail Rule
@@ -10,11 +9,7 @@ Guide the user through creating one or more new rules for their repository.
 
 ## Determining the Repository
 
-If `$ARGUMENTS` is not empty, use it as the repository (`owner/repo`) for all `detail rules` commands.
-
-Otherwise, the Detail CLI will infer the repository from the git remote. Use the CLI with no repository specified.
-
-If commands fail to infer the repository, ask the user to provide the repository and use it for the `detail rules` commands.
+The Detail CLI infers the repository from the git remote; if the user specifies a different repo, pass it explicitly to the CLI commands.
 
 ## Prerequisites
 
@@ -36,12 +31,12 @@ Ask the user what they want to do:
 
 **For a specific rule**, build the command from whatever context the user provided. At least one of `--description`, `--bug-ids`, or `--commit-shas` is required:
 ```bash
-detail rules create $ARGUMENTS [--description "<description>"] [--bug-ids <id1,id2>] [--commit-shas <sha1,sha2>]
+detail rules create [--description "<description>"] [--bug-ids <id1,id2>] [--commit-shas <sha1,sha2>]
 ```
 
 **For AI-proposed rules**:
 ```bash
-detail rules propose $ARGUMENTS
+detail rules propose
 ```
 
 Both commands return a request ID (`rcr_...`). Save it — you will need it to poll for status.


### PR DESCRIPTION
## Summary

- Both skills currently template `$ARGUMENTS` into commands like `detail bugs list $ARGUMENTS`. When the skill is invoked with prose ("triage today's bugs"), Claude Code forwards the full sentence as `$ARGUMENTS`, producing `detail bugs list "Check for detail bugs..."` — the CLI treats that as a literal `owner/repo` and every command in the skill fails.
- The CLI already infers the repo from the git remote, and Claude can pass an explicit flag if a different repo is needed, so the templating doesn't carry its weight.
- This drop-the-arg approach is the cleaner alternative to the shape-checking half-fix in usedetail/detail#11222.

## Changes

- Removed `argument-hint: <owner/repo>` from both skill frontmatters.
- Removed every `$ARGUMENTS` interpolation from command examples.
- Replaced the "Determining the Repository" section in each skill with a single sentence pointing at git-remote inference and explicit flags.

## Test plan

- [ ] `grep -r '\$ARGUMENTS' .claude/skills/` returns nothing
- [ ] `grep -r 'argument-hint' .claude/skills/` returns nothing
- [ ] Invoke `detail-bugs` skill with a prose request and confirm the `detail bugs list` command runs cleanly
- [ ] Invoke `detail-create-rules` skill and confirm the `detail rules create` / `detail rules propose` commands run cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)