### PR TITLE
refactor(config): remove dead save_config function

### DIFF
--- a/src/config/storage.rs
+++ b/src/config/storage.rs
@@ -64,16 +64,6 @@ pub fn load_config() -> Result<Config> {
     toml::from_str(&contents).context("Failed to parse config")
 }
 
-pub fn save_config(config: &Config) -> Result<()> {
-    let path = config_path()?;
-    let contents = toml::to_string_pretty(config)?;
-    let file = File::create(&path)?;
-    file.lock_exclusive()?;
-    (&file).write_all(contents.as_bytes())?;
-    file.unlock()?;
-    Ok(())
-}
-
 /// Atomically read-modify-write the config file under an exclusive lock.
 ///
 /// Preserves comments and formatting the user may have added by hand. The
@@ -262,24 +252,7 @@ mod tests {
         });
     }
 
-    // ── save / load round-trip ───────────────────────────────────────
-
-    #[test]
-    fn save_then_load_config() {
-        with_temp_config(|| {
-            let config = Config {
-                api_url: Some("https://test.dev".into()),
-                app_url: None,
-                check_for_updates: true,
-                last_update_check: None,
-                api_token: Some("tok".into()),
-            };
-            save_config(&config).unwrap();
-            let loaded = load_config().unwrap();
-            assert_eq!(loaded.api_url.as_deref(), Some("https://test.dev"));
-            assert_eq!(loaded.api_token.as_deref(), Some("tok"));
-        });
-    }
+    // ── load_config ──────────────────────────────────────────────────
 
     #[test]
     fn load_config_partial_file_defaults_check_for_updates() {
@@ -492,7 +465,7 @@ api_token = \"old_token\"
 
         with_temp_config(|| {
             // Initialize config
-            save_config(&Config::default()).unwrap();
+            update_config(|_| {}).unwrap();
 
             let handles: Vec<_> = (0..10)
                 .map(|i| {


### PR DESCRIPTION
## Summary
- Deletes the unused `save_config` function in `src/config/storage.rs` and its dedicated `save_then_load_config` round-trip test.
- Updates `concurrent_update_config_does_not_corrupt` to seed the config file with `update_config(|_| {})` instead of `save_config(&Config::default())`.
- Closes Detail bug `bug_3b5a0cd5-08da-482d-b222-ce83e5acb944` (linked GH #269), which reported a truncate-before-lock race in `save_config`. Fixing the race isn't worth it since the function has no production callers — `grep -rn save_config --include='*.rs'` showed only the function definition and two `#[cfg(test)]` sites in the same file.

## Note for reviewers
`save_config` is `pub`, and although `Cargo.toml` only declares a `[[bin]]`, the crate also has `src/lib.rs`, so Cargo auto-builds a library and `detail_cli::config::storage::save_config` was technically part of the library's public API. We don't publish to crates.io and there are no other consumers of this crate's library surface that we know of, but flagging in case you want to weigh that.

## Test plan
- [x] `cargo test` — all 289 lib + 17 integration tests pass
- [x] `grep -rn save_config --include='*.rs'` returns no matches after the change
- [x] `concurrent_update_config_does_not_corrupt` still passes with the new init line

🤖 Generated with [Claude Code](https://claude.com/claude-code)