### PR TITLE
fix(satisfying_sort): drop dead source_region gate that hid triangle pixels

### DIFF
--- a/src/commands/satisfying_sort/logo_math.rs
+++ b/src/commands/satisfying_sort/logo_math.rs
@@ -74,40 +74,6 @@ pub(super) fn triangle_nominal_index(nx: f32, n: usize, region: LogoRegion) -> u
     floor_f32_to_usize(t * usize_to_f32(n)).min(n - 1)
 }
 
-pub(super) fn shuffled_index_for_nominal(array: &[usize], nominal_index: usize, n: usize) -> usize {
-    let n = n.max(1);
-    array
-        .get(nominal_index.min(n - 1))
-        .copied()
-        .unwrap_or_else(|| nominal_index.saturating_add(1))
-        .saturating_sub(1)
-        .min(n - 1)
-}
-
-pub(super) fn source_local_x_for_index(
-    shuffled_index: usize,
-    n: usize,
-    region: LogoRegion,
-    viewport_width: usize,
-) -> usize {
-    if viewport_width == 0 {
-        return 0;
-    }
-    let max_col = viewport_width - 1;
-    let unit = if n <= 1 {
-        0.0
-    } else {
-        usize_to_f32(shuffled_index.min(n - 1)) / usize_to_f32(n - 1)
-    };
-
-    let nx = match region {
-        LogoRegion::TopTriangle => (unit * TOP_TRIANGLE_X_SPAN).clamp(0.0, 1.0),
-        LogoRegion::BottomTriangle => (1.0 - unit * BOTTOM_TRIANGLE_X_SPAN).clamp(0.0, 1.0),
-        LogoRegion::Static | LogoRegion::Empty => unit.clamp(0.0, 1.0),
-    };
-    round_f32_to_usize(nx * usize_to_f32(max_col)).min(max_col)
-}
-
 pub(super) fn logo_region_at(
     local_x: usize,
     local_y: usize,
@@ -239,25 +205,6 @@ mod tests {
             triangle_nominal_index(1.0, n, LogoRegion::BottomTriangle),
             0
         );
-    }
-
-    #[test]
-    fn source_column_uses_shuffled_order() {
-        let array = vec![2, 1, 3, 4, 5, 6, 7, 8];
-        let n = array.len();
-        let viewport_width = 80;
-
-        let nominal_left = 0_usize;
-        let nominal_next = 1_usize;
-        let shuffled_left = shuffled_index_for_nominal(&array, nominal_left, n);
-        let shuffled_next = shuffled_index_for_nominal(&array, nominal_next, n);
-
-        let source_left =
-            source_local_x_for_index(shuffled_left, n, LogoRegion::TopTriangle, viewport_width);
-        let source_next =
-            source_local_x_for_index(shuffled_next, n, LogoRegion::TopTriangle, viewport_width);
-
-        assert!(source_left > source_next);
     }
 
     #[test]

--- a/src/commands/satisfying_sort/render.rs
+++ b/src/commands/satisfying_sort/render.rs
@@ -1,9 +1,6 @@
 use ratatui::{style::Color, Frame};
 
-use super::logo_math::{
-    logo_region_at, shuffled_index_for_nominal, source_local_x_for_index, triangle_nominal_index,
-    LogoRegion,
-};
+use super::logo_math::{logo_region_at, triangle_nominal_index, LogoRegion};
 use super::numeric::{floor_f32_to_usize, round_f32_to_usize, usize_to_f32};
 use super::sort_state::{BandStyle, SortState};
 
@@ -203,13 +200,6 @@ fn pixel_style_at(ctx: &PixelQueryCtx<'_>, local_x: usize, local_y: usize) -> Pi
     if matches!(region, LogoRegion::TopTriangle | LogoRegion::BottomTriangle) {
         let nx = usize_to_f32(local_x) / ctx.x_den;
         let nominal_index = triangle_nominal_index(nx, ctx.n, region);
-        let shuffled_index = visual_source_index_for_nominal(ctx.state, nominal_index, ctx.n);
-        let source_x = source_local_x_for_index(shuffled_index, ctx.n, region, ctx.viewport_width);
-        let source_region =
-            logo_region_at(source_x, local_y, ctx.viewport_width, ctx.viewport_height);
-        if source_region != region {
-            return PixelStyle::Off;
-        }
         return match ctx
             .state
             .style_for_index_with_min_window(nominal_index, ctx.active_min_window)
@@ -221,21 +211,6 @@ fn pixel_style_at(ctx: &PixelQueryCtx<'_>, local_x: usize, local_y: usize) -> Pi
     }
 
     PixelStyle::Base
-}
-
-fn visual_source_index_for_nominal(state: &SortState, nominal_index: usize, n: usize) -> usize {
-    let n = n.max(1);
-    let nominal_index = nominal_index.min(n - 1);
-
-    if state.scan_complete()
-        || state
-            .current_scan_index()
-            .is_some_and(|scan| nominal_index <= scan)
-    {
-        return nominal_index;
-    }
-
-    shuffled_index_for_nominal(state.source_array(), nominal_index, n)
 }
 
 fn min_active_window_for_columns(n: usize, viewport_width: usize, target_columns: usize) -> usize {
@@ -343,6 +318,43 @@ mod tests {
     fn halfblocks_aspect_is_in_valid_range() {
         let aspect = halfblocks_cell_aspect_x();
         assert!((0.5..=4.0).contains(&aspect));
+    }
+
+    #[test]
+    fn idle_phase_populates_every_triangle_pixel() {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let state = SortState::new(1000, &mut rng);
+        let viewport = compute_logo_viewport(140, 50, 1.0).expect("viewport");
+
+        let n = state.len().max(1);
+        let x_den = usize_to_f32(viewport.width.saturating_sub(1).max(1));
+        let active_min_window = min_active_window_for_columns(n, viewport.width, 2);
+        let ctx = PixelQueryCtx {
+            state: &state,
+            n,
+            viewport_width: viewport.width,
+            viewport_height: viewport.side,
+            x_den,
+            active_min_window,
+        };
+
+        let mut triangle_pixels = 0_usize;
+        for local_y in 0..viewport.side {
+            for local_x in 0..viewport.width {
+                let region =
+                    logo_region_at(local_x, local_y, ctx.viewport_width, ctx.viewport_height);
+                if matches!(region, LogoRegion::TopTriangle | LogoRegion::BottomTriangle) {
+                    triangle_pixels = triangle_pixels.saturating_add(1);
+                    let style = pixel_style_at(&ctx, local_x, local_y);
+                    assert_eq!(
+                        style,
+                        PixelStyle::Base,
+                        "triangle pixel at ({local_x}, {local_y}) should be Base during Idle"
+                    );
+                }
+            }
+        }
+        assert!(triangle_pixels > 0, "expected non-empty triangle region");
     }
 
     #[test]

--- a/src/commands/satisfying_sort/sort_state.rs
+++ b/src/commands/satisfying_sort/sort_state.rs
@@ -42,21 +42,6 @@ impl SortState {
         self.source_array.len()
     }
 
-    pub(super) fn source_array(&self) -> &[usize] {
-        &self.source_array
-    }
-
-    pub(super) const fn current_scan_index(&self) -> Option<usize> {
-        match self.phase {
-            Phase::Sorting { scan_start } => Some(scan_start),
-            Phase::Idle | Phase::Completion { .. } => None,
-        }
-    }
-
-    pub(super) const fn scan_complete(&self) -> bool {
-        matches!(self.phase, Phase::Completion { .. })
-    }
-
     pub(super) const fn apply_sort_step(&mut self, index: usize) {
         self.phase = Phase::Sorting { scan_start: index };
     }
@@ -142,18 +127,6 @@ mod tests {
     }
 
     #[test]
-    fn state_source_array_is_permutation_after_reset() {
-        let mut rng = SmallRng::seed_from_u64(13);
-        let mut state = SortState::new(128, &mut rng);
-        state.reset(&mut rng);
-
-        let mut array = state.source_array().to_vec();
-        array.sort_unstable();
-        let expected: Vec<usize> = (1..=128).collect();
-        assert_eq!(array, expected);
-    }
-
-    #[test]
     fn style_for_index_respects_active_window() {
         let mut rng = SmallRng::seed_from_u64(1);
         let mut state = SortState::new(64, &mut rng);
@@ -188,25 +161,5 @@ mod tests {
             BandStyle::Complete
         );
         assert_eq!(state.style_for_index_with_min_window(7, 0), BandStyle::Idle);
-    }
-
-    #[test]
-    fn phase_helpers_match_state_transitions() {
-        let mut rng = SmallRng::seed_from_u64(21);
-        let mut state = SortState::new(32, &mut rng);
-        assert_eq!(state.current_scan_index(), None);
-        assert!(!state.scan_complete());
-
-        state.apply_sort_step(4);
-        assert_eq!(state.current_scan_index(), Some(4));
-        assert!(!state.scan_complete());
-
-        state.finalize_sort_pass();
-        assert_eq!(state.current_scan_index(), None);
-        assert!(state.scan_complete());
-
-        state.reset(&mut rng);
-        assert_eq!(state.current_scan_index(), None);
-        assert!(!state.scan_complete());
     }
 }


### PR DESCRIPTION
## Summary
- `pixel_style_at` ran a `source_region != region` check that mixed a 1D `source_x` (computed from a shuffled array index) with the current pixel's 2D `local_y`. That comparison has no geometric meaning and was hiding ~27.7% of triangle pixels during the Idle and Sorting phases of the satisfying-sort animation. The holes only "disappeared" during Completion because `visual_source_index_for_nominal` happened to return `nominal_index` once the scan finished, accidentally making `source_x ≈ local_x`.
- The shuffled-source path was never used to color pixels — styling reads `nominal_index` via `style_for_index_with_min_window` — so the gate was effectively dead code that only removed pixels. Dropped the gate and the helpers that exclusively supported it (`shuffled_index_for_nominal`, `source_local_x_for_index`, `visual_source_index_for_nominal`, plus the `SortState` accessors used only by them).
- Added a regression test (`idle_phase_populates_every_triangle_pixel`) that walks the full viewport during Idle and asserts every `TopTriangle`/`BottomTriangle` pixel renders as `Base`.

Fixes #268. Detail bug: `bug_85d5ca30-433d-43d9-9ffd-5e80c7d4e8aa`.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` (288 passed, including the new regression test)
- [x] `cargo xtask check`
- [ ] Manual smoke: run the satisfying-sort animation and confirm Idle has no holes, Sorting shows the blue active sweep, and Completion turns everything green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)