### PR TITLE
Make satisfying-sort animation ~3x faster (sort pass only)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core 0.10.0",
+ "rand_core",
 ]
 
 [[package]]
@@ -528,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -672,7 +672,7 @@ dependencies = [
  "open",
  "percent-encoding",
  "progenitor",
- "rand 0.10.1",
+ "rand",
  "ratatui",
  "regress",
  "reqwest",
@@ -921,11 +921,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -935,11 +933,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.0",
+ "rand_core",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1711,15 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,15 +1823,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1889,42 +1881,13 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core 0.10.0",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1932,6 +1895,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "ratatui"
@@ -3774,26 +3746,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/src/commands/satisfying_sort/mod.rs
+++ b/src/commands/satisfying_sort/mod.rs
@@ -25,7 +25,10 @@ use render::{compute_logo_viewport, halfblocks_cell_aspect_x, render_halfblocks_
 use sort_state::{sort_delay_ms, SortState};
 
 const ARRAY_SIZE: usize = 1000;
-const SPEED: u8 = 20;
+// Per-step render cost is fixed, so wall-clock speed scales sub-linearly with the
+// derived step delay; SPEED is tuned by measurement (82 => ~9ms/step) rather than
+// picked for a clean fraction.
+const SPEED: u8 = 82;
 const NOISE: u8 = 100;
 const GREEN_SPEED: u8 = 50;
 const LOOP_DELAY_MS: u64 = 2000;

--- a/src/commands/satisfying_sort/mod.rs
+++ b/src/commands/satisfying_sort/mod.rs
@@ -25,9 +25,6 @@ use render::{compute_logo_viewport, halfblocks_cell_aspect_x, render_halfblocks_
 use sort_state::{sort_delay_ms, SortState};
 
 const ARRAY_SIZE: usize = 1000;
-// Per-step render cost is fixed, so wall-clock speed scales sub-linearly with the
-// derived step delay; SPEED is tuned by measurement (82 => ~9ms/step) rather than
-// picked for a clean fraction.
 const SPEED: u8 = 82;
 const NOISE: u8 = 100;
 const GREEN_SPEED: u8 = 50;


### PR DESCRIPTION
Speeds up the `detail satisfying-sort` **sort pass** by ~3x, leaving the green completion finale untouched.

## What changed
The sort pass speed is driven by `sort_delay_ms()`, which derives a per-step sleep from the `SPEED` constant. The green finale is driven separately by `GREEN_SPEED`, so it's unaffected. I bumped `SPEED` from `20` to `82`.

Why `82` and not a clean "divide by 3": each step also has a fixed render cost, so wall-clock time is *not* linear in the step delay — dividing the sleep by 3 only got to ~2.36x. I tuned `SPEED` by measurement so the step delay lands at ~9ms, which produces a real ~3x end-to-end speedup.

## Verification (measured in a terminal via PTY)
| Pass | Before | After | Ratio |
|------|--------|-------|-------|
| Sort pass | 9870 ms | 3311 ms | **2.98x faster** |
| Green finale | ~1186 ms | ~1186 ms | unchanged ✅ |

`cargo test` passes (19 satisfying-sort tests), build is warning-free, and a final smoke run of the built binary renders and exits cleanly with no panics.

[![View in Indent](https://assets.indent.com/view-in-indent.svg)](https://app.indent.com/c/019f6ec9-653e-7607-990c-b9652d4e88d4) [![View in Slack](https://assets.indent.com/slack-thread.svg)](https://detail-dev.slack.com/archives/C0AEA3ACH5H/p1784270113128459)
Tag `@indent` to continue the conversation here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->