### PR TITLE
feat: show Detail fix PR on bugs list and show views

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -53,6 +53,9 @@
             "nullable": true,
             "type": "string"
           },
+          "fixPr": {
+            "$ref": "#/components/schemas/FixPr"
+          },
           "id": {
             "$ref": "#/components/schemas/BugId"
           },
@@ -184,7 +187,8 @@
           "jira",
           "asana",
           "github_issue",
-          "bug_fix_check"
+          "bug_fix_check",
+          "detail_fix_pr"
         ],
         "type": "string"
       },
@@ -207,6 +211,30 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "FixPr": {
+        "properties": {
+          "prNumber": {
+            "type": "integer"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prNumber",
+          "url",
+          "state"
+        ],
         "type": "object"
       },
       "IntroducedIn": {

--- a/src/api/types.rs
+++ b/src/api/types.rs
@@ -6,10 +6,10 @@ use crate::utils::datetime::{format_date, format_datetime};
 // Re-export generated types as the public API for this crate.
 pub use super::generated::types::{
     Bug, BugCounts, BugDismissalReason, BugId, BugReview, BugReviewId, BugReviewState,
-    CreatePublicBugReviewBody, CreateRuleInput, CreateRuleResponse, IntroducedIn, LinkedIssue,
-    LinkedIssueTracker, ListPublicBugsWorkflowRequestId, Org, OrgId, Repo, RepoId, Rule,
-    RuleCreationRequestId, RuleId, RuleListItem, RuleRequestResult, RuleRequestStatus, RuleStatus,
-    Scan, ScanInitiator, ScanType, WorkflowStatus,
+    CreatePublicBugReviewBody, CreateRuleInput, CreateRuleResponse, FixPr, IntroducedIn,
+    LinkedIssue, LinkedIssueTracker, ListPublicBugsWorkflowRequestId, Org, OrgId, Repo, RepoId,
+    Rule, RuleCreationRequestId, RuleId, RuleListItem, RuleRequestResult, RuleRequestStatus,
+    RuleStatus, Scan, ScanInitiator, ScanType, WorkflowStatus,
 };
 
 // Friendlier aliases for the generated response-wrapper names.
@@ -80,6 +80,15 @@ pub fn format_linked_issue(issue: &LinkedIssue) -> String {
             |url| format!("{tracker}: {} \u{2014} {url}", issue.issue_id),
         ),
     }
+}
+
+/// Format the Detail-generated fix PR (number, state, and URL) for the
+/// detail/show view, rendered as `#<number> (<state>) — <url>`.
+pub fn format_fix_pr(fix_pr: &FixPr) -> String {
+    format!(
+        "#{} ({}) \u{2014} {}",
+        fix_pr.pr_number, fix_pr.state, fix_pr.url
+    )
 }
 
 // ── clap::ValueEnum ──────────────────────────────────────────────────
@@ -176,6 +185,12 @@ impl Formattable for Bug {
                 .collect::<Vec<_>>()
                 .join(", ");
             pairs.push(("Linked Issues", formatted));
+        }
+        if let Some(fix_pr) = &self.fix_pr {
+            pairs.push((
+                "Fix PR",
+                format!("#{} ({})", fix_pr.pr_number, fix_pr.state),
+            ));
         }
         (self.title.clone(), pairs)
     }
@@ -449,6 +464,41 @@ mod tests {
         assert_eq!(
             v,
             Some(&"PR #42 (abc1234) on 2024-12-23 by alice".to_string())
+        );
+    }
+
+    // ── fix PR ───────────────────────────────────────────────────────
+
+    #[test]
+    fn bug_card_includes_fix_pr_when_present() {
+        let bug: Bug = serde_json::from_value(serde_json::json!({
+            "id": "bug_fixed", "title": "...", "summary": "...",
+            "createdAt": 1, "repoId": "repo_1", "linkedIssues": [],
+            "fixPr": { "prNumber": 42, "url": "https://x/pull/42", "state": "merged" }
+        }))
+        .expect("valid Bug JSON");
+        let (_, pairs) = bug.to_card();
+        let v = pairs.iter().find(|(k, _)| *k == "Fix PR").map(|(_, v)| v);
+        assert_eq!(v, Some(&"#42 (merged)".to_string()));
+    }
+
+    #[test]
+    fn bug_card_omits_fix_pr_when_absent() {
+        let (_, pairs) = sample_bug().to_card();
+        assert!(!pairs.iter().any(|(k, _)| *k == "Fix PR"));
+    }
+
+    #[test]
+    fn format_fix_pr_includes_number_state_and_url() {
+        let fix_pr: FixPr = serde_json::from_value(serde_json::json!({
+            "prNumber": 42,
+            "url": "https://github.com/acme/repo/pull/42",
+            "state": "open"
+        }))
+        .expect("valid FixPr JSON");
+        assert_eq!(
+            format_fix_pr(&fix_pr),
+            "#42 (open) \u{2014} https://github.com/acme/repo/pull/42"
         );
     }
 

--- a/src/commands/bugs.rs
+++ b/src/commands/bugs.rs
@@ -7,8 +7,9 @@ use dialoguer::{Input, Select};
 
 use crate::api::client::ApiClient;
 use crate::api::types::{
-    dismissal_reason_label, format_introduced_in, format_linked_issue, review_state_label, Bug,
-    BugDismissalReason, BugId, BugReviewState, ListPublicBugsWorkflowRequestId, RepoId,
+    dismissal_reason_label, format_fix_pr, format_introduced_in, format_linked_issue,
+    review_state_label, Bug, BugDismissalReason, BugId, BugReviewState,
+    ListPublicBugsWorkflowRequestId, RepoId,
 };
 use crate::output::{output_list, SectionRenderer};
 use crate::utils::datetime::{format_datetime, parse_time_spec};
@@ -332,6 +333,9 @@ fn render_bug_show(bug: &Bug) -> Result<()> {
     }
     for issue in &bug.linked_issues {
         pairs.push(("Issue", format_linked_issue(issue)));
+    }
+    if let Some(fix_pr) = &bug.fix_pr {
+        pairs.push(("Fix PR", format_fix_pr(fix_pr)));
     }
     SectionRenderer::new()
         .key_value("", &pairs)


### PR DESCRIPTION
## What

Renders the Detail-generated fix PR (`fixPr`) on the `bugs` views, now that the public API exposes it.

- **`bugs list`** (table + `--format json`): a compact `Fix PR   #<number> (<state>)` row, alongside the existing `Introduced` / `Linked Issues` rows.
- **`bugs show`**: a `Fix PR   #<number> (<state>) — <url>` row, next to the per-issue rows.

`fixPr` is optional — bugs without a Detail fix PR simply omit the row (the field is only populated for repos with the bug-fix workflow enabled).

## Changes

- `openapi.json`: regenerated via `cargo xtask generate-openapi` — picks up the new optional `Bug.fixPr` + `FixPr` schema.
- `src/api/types.rs`: re-export `FixPr`, add a `format_fix_pr` helper, add the Fix PR row to the `Bug` list card, plus unit tests.
- `src/commands/bugs.rs`: add the Fix PR row (with URL) to `render_bug_show`.

## Verification

- `cargo xtask check` (openapi.json matches upstream, HELP.md up to date), `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build`, `cargo test` — all green.
- Smoke-tested the built binary against the live API: `bugs list` shows `#13922 (open)` / `#13921 (closed)`, and `bugs show` shows `#13599 (merged) — https://github.com/usedetail/detail/pull/13599` — across all three states.

Backend side (exposes the field): usedetail/detail#14560 (merged + deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/319" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->