### PR TITLE
chore: refresh openapi vendor artifact

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -53,6 +53,9 @@
             "nullable": true,
             "type": "string"
           },
+          "fixPr": {
+            "$ref": "#/components/schemas/FixPr"
+          },
           "id": {
             "$ref": "#/components/schemas/BugId"
           },
@@ -184,7 +187,8 @@
           "jira",
           "asana",
           "github_issue",
-          "bug_fix_check"
+          "bug_fix_check",
+          "detail_fix_pr"
         ],
         "type": "string"
       },
@@ -207,6 +211,30 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "FixPr": {
+        "properties": {
+          "prNumber": {
+            "type": "integer"
+          },
+          "state": {
+            "enum": [
+              "open",
+              "merged",
+              "closed"
+            ],
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "prNumber",
+          "url",
+          "state"
+        ],
         "type": "object"
       },
       "IntroducedIn": {


### PR DESCRIPTION
## Summary
- Regenerated `openapi.json` with `cargo xtask generate-openapi`.
- Verified vendored artifacts with `cargo xtask check`.
- Completed broader refresh:
  - `cargo build`
  - `cargo fmt --check`
  - `cargo clippy -- -D warnings`
  - `cargo check`
  - `cargo test`

## Rebase
- Rebased branch onto `origin/main` before opening this PR.
