### PR TITLE
chore: release v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "detail-cli"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "axoupdater",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "xtask"]
 
 [package]
 name = "detail-cli"
-version = "0.2.8"
+version = "0.2.9"
 edition = "2021"
 authors = ["Detail Team <eng@detail.dev>"]
 license = "MIT"


### PR DESCRIPTION
Bumps `detail-cli` to v0.2.9, following the `cut-release` skill (patch bump in `Cargo.toml` + `Cargo.lock`; `release.yml` tags `v0.2.9` and publishes the GitHub Release on merge to `main`).

Changes since v0.2.8:
- feat: support jj repos for repo inference and skill install (#324)

`cargo check --locked` passes.

[![View in Indent](https://assets.indent.com/view-in-indent.svg)](https://app.indent.com/c/019fc658-5f4a-7964-a903-64dab3c4d82d) [![View in Slack](https://assets.indent.com/slack-thread.svg)](https://detail-dev.slack.com/archives/C0AEA3ACH5H/p1785738438774999?thread_ts=1785738438.774999&cid=C0AEA3ACH5H)
Tag `@indent` to continue the conversation here.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/usedetail/cli/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->